### PR TITLE
feat: Add enrichment using OpenSSF Scorecard data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 * [ecosyste.ms](https://ecosyste.ms)
 * [Snyk](https://snyk.io)
+* [OpenSSF Scorecard](https://securityscorecards.dev/)
 
 By enrich, we mean add additional information. You put in an SBOM, and you get a richer SBOM back. In many cases SBOMs have a minimum of information, often just the name and version of a given package. By enriching that with additional information we can make better decisions about the packages we're using.
 
@@ -103,7 +104,7 @@ parlay snyk enrich testing/sbom.cyclonedx.json
 
 Snyk will add a new [vulnerability](https://cyclonedx.org/docs/1.4/json/#vulnerabilities) attribute to the SBOM, for example:
 
-```
+```json
 "vulnerabilities": [
   {
     "bom-ref": "68-subtext@6.0.12",
@@ -149,6 +150,39 @@ Return raw JSON information about vulnerabilities in a specific package from Sny
 ```
 parlay snyk package pkg:npm/sqliter@1.0.1
 ```
+
+## Enriching with OpenSSF Scorecard
+
+The [OpenSSF Scorecard project](https://securityscorecards.dev/) tests various aspects of a projects security posture and provides a score. `parlay` supports added a link to this data with the `parlay scorecard enrich` command.
+
+
+You can use this like so:
+
+```
+parlay scorecard enrich testing/sbom2.cyclonedx.json
+```
+
+This will currently add an external reference to the [Scorecard API](https://api.securityscorecards.dev/) which can be used to retrieve the full scorecard.
+
+```json
+{
+  "bom-ref": "103-org.springframework:spring-webmvc@5.3.3",
+  "type": "library",
+  "name": "org.springframework:spring-webmvc",
+  "version": "5.3.3",
+  "purl": "pkg:maven/org.springframework/spring-webmvc@5.3.3",
+  "externalReferences": [
+    {
+      "url": "https://api.securityscorecards.dev/projects/github.com/spring-projects/spring-framework",
+      "comment": "OpenSSF Scorecard",
+      "type": "other"
+    }
+  ]
+},
+```
+
+We're currently looking at the best way of encoding some of the scorecard data in the SBOM itself as well.
+
 
 ## What about enriching with other data sources?
 
@@ -235,3 +269,18 @@ The various services used to enrich the SBOM data have data for a subset of purl
 * `rpm` 
 * `swift`
 
+### OpenSSF Scorecard
+
+* `apk`
+* `cargo`
+* `cocoapods`
+* `composer`
+* `gem`
+* `golang`
+* `hex`
+* `maven`
+* `npm`
+* `nuget`
+* `pypi`
+
+Note that Scorecard data is available only for a subset of projects from supported Git repositories. See the [Scorecard project](https://github.com/ossf/scorecard) for more information.

--- a/internal/commands/default.go
+++ b/internal/commands/default.go
@@ -3,9 +3,10 @@ package commands
 import (
 	"os"
 
-	"github.com/snyk/parlay/internal/commands/ecosystems"
-	"github.com/snyk/parlay/internal/commands/snyk"
 	"github.com/snyk/parlay/internal/commands/deps"
+	"github.com/snyk/parlay/internal/commands/ecosystems"
+	"github.com/snyk/parlay/internal/commands/scorecard"
+	"github.com/snyk/parlay/internal/commands/snyk"
 
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
@@ -40,6 +41,7 @@ func NewDefaultCommand() *cobra.Command {
 	cmd.AddCommand(ecosystems.NewEcosystemsRootCommand(logger))
 	cmd.AddCommand(snyk.NewSnykRootCommand(logger))
 	cmd.AddCommand(deps.NewDepsRootCommand(logger))
+	cmd.AddCommand(scorecard.NewRootCommand(logger))
 
 	return &cmd
 }

--- a/internal/commands/scorecard/enrich.go
+++ b/internal/commands/scorecard/enrich.go
@@ -1,0 +1,40 @@
+package scorecard
+
+import (
+	"bytes"
+	"os"
+
+  "github.com/snyk/parlay/internal/utils"
+	"github.com/snyk/parlay/lib/scorecard"
+
+	cdx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/rs/zerolog"
+	"github.com/spf13/cobra"
+)
+
+func NewEnrichCommand(logger zerolog.Logger) *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "enrich <sbom>",
+		Short: "Enrich an SBOM with OpenSSF Scorecard data",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			b, err := utils.GetUserInput(args[0], os.Stdin)
+			if err != nil {
+				logger.Fatal().Err(err).Msg("Problem reading input")
+			}
+
+			bom := new(cdx.BOM)
+			decoder := cdx.NewBOMDecoder(bytes.NewReader(b), cdx.BOMFileFormatJSON)
+			if err = decoder.Decode(bom); err != nil {
+				logger.Fatal().Err(err).Msg("Input needs to be a valid CycloneDX SBOM")
+			}
+
+			bom = scorecard.EnrichSBOM(bom)
+			err = cdx.NewBOMEncoder(os.Stdout, cdx.BOMFileFormatJSON).Encode(bom)
+			if err != nil {
+				logger.Fatal().Err(err).Msg("Failed to envode new SBOM")
+			}
+		},
+	}
+	return &cmd
+}

--- a/internal/commands/scorecard/root.go
+++ b/internal/commands/scorecard/root.go
@@ -1,0 +1,23 @@
+package scorecard
+
+import (
+	"github.com/rs/zerolog"
+	"github.com/spf13/cobra"
+)
+
+func NewRootCommand(logger zerolog.Logger) *cobra.Command {
+	cmd := cobra.Command{
+		Use:                   "scorecard",
+		Short:                 "Commands for using parlay with OpenSSF Scorecard",
+		Aliases:               []string{"s"},
+		DisableFlagsInUseLine: true,
+		SilenceUsage:          true,
+		Run: func(cmd *cobra.Command, args []string) {
+			_ = cmd.Help()
+		},
+	}
+
+	cmd.AddCommand(NewEnrichCommand(logger))
+
+	return &cmd
+}

--- a/lib/scorecard/enrich.go
+++ b/lib/scorecard/enrich.go
@@ -1,0 +1,58 @@
+package scorecard
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/snyk/parlay/lib/ecosystems"
+
+	cdx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/package-url/packageurl-go"
+	"github.com/remeh/sizedwaitgroup"
+)
+
+func enrichExternalReference(component cdx.Component, url string, comment string, refType cdx.ExternalReferenceType) cdx.Component {
+	ext := cdx.ExternalReference{
+		URL:     url,
+		Comment: comment,
+		Type:    refType,
+	}
+	if component.ExternalReferences == nil {
+		component.ExternalReferences = &[]cdx.ExternalReference{ext}
+	} else {
+		*component.ExternalReferences = append(*component.ExternalReferences, ext)
+	}
+	return component
+}
+
+func EnrichSBOM(bom *cdx.BOM) *cdx.BOM {
+	if bom.Components == nil {
+		return bom
+	}
+
+	wg := sizedwaitgroup.New(20)
+	newComponents := make([]cdx.Component, len(*bom.Components))
+	for i, component := range *bom.Components {
+		wg.Add()
+		go func(component cdx.Component, i int) {
+			purl, _ := packageurl.FromString(component.PackageURL)
+			resp, err := ecosystems.GetPackageData(purl)
+			if err == nil && resp.JSON200 != nil && resp.JSON200.RepositoryUrl != nil {
+				scorecardUrl := strings.ReplaceAll(*resp.JSON200.RepositoryUrl, "https://", "https://api.securityscorecards.dev/projects/")
+				response, err := http.Get(scorecardUrl)
+				if err == nil {
+					defer response.Body.Close()
+					if response.StatusCode == http.StatusOK {
+						component = enrichExternalReference(component, scorecardUrl, "OpenSSF Scorecard", cdx.ERTypeOther)
+					}
+				}
+			}
+			newComponents[i] = component
+			wg.Done()
+		}(component, i)
+	}
+	wg.Wait()
+	bom.Components = &newComponents
+
+	return bom
+}

--- a/lib/scorecard/enrich_test.go
+++ b/lib/scorecard/enrich_test.go
@@ -1,0 +1,114 @@
+package scorecard
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	cdx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/jarcoal/httpmock"
+)
+
+func TestEnrichSBOM(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("GET", `=~^https://packages.ecosyste.ms/api/v1/registries`,
+		func(req *http.Request) (*http.Response, error) {
+			return httpmock.NewJsonResponse(200, map[string]interface{}{
+				"repository_url": "https://example.com/repository",
+			})
+		})
+
+	httpmock.RegisterNoResponder(func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("unexpected HTTP request: " + req.URL.String())
+	})
+
+	scorecardUrl := "https://api.securityscorecards.dev/projects/example.com/repository"
+	httpmock.RegisterResponder("GET", scorecardUrl,
+		httpmock.NewStringResponder(http.StatusOK, "{}"))
+
+	bom := cdx.NewBOM()
+	bom.Components = &[]cdx.Component{
+		{
+			PackageURL: "pkg:/example",
+		},
+	}
+
+	enrichedBOM := EnrichSBOM(bom)
+
+	assert.NotNil(t, enrichedBOM.Components)
+	assert.Len(t, *enrichedBOM.Components, 1)
+
+	enrichedComponent := (*enrichedBOM.Components)[0]
+	assert.NotNil(t, enrichedComponent.ExternalReferences)
+	assert.Len(t, *enrichedComponent.ExternalReferences, 1)
+	assert.Equal(t, scorecardUrl, (*enrichedComponent.ExternalReferences)[0].URL)
+	assert.Equal(t, "OpenSSF Scorecard", (*enrichedComponent.ExternalReferences)[0].Comment)
+	assert.Equal(t, cdx.ERTypeOther, (*enrichedComponent.ExternalReferences)[0].Type)
+
+	total := httpmock.GetTotalCallCount()
+	assert.Equal(t, 2, total)
+	calls := httpmock.GetCallCountInfo()
+	assert.Equal(t, 1, calls[`GET =~^https://packages.ecosyste.ms/api/v1/registries`])
+}
+
+func TestEnrichSBOM_ErrorFetchingPackageData(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("GET", `=~^https://packages.ecosyste.ms/api/v1/registries`,
+		httpmock.NewErrorResponder(assert.AnError))
+
+	httpmock.RegisterNoResponder(func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("unexpected HTTP request: " + req.URL.String())
+	})
+
+	bom := cdx.NewBOM()
+	bom.Components = &[]cdx.Component{
+		{
+			PackageURL: "pkg:/example",
+		},
+	}
+
+	enrichedBOM := EnrichSBOM(bom)
+
+	assert.NotNil(t, enrichedBOM.Components)
+	assert.Len(t, *enrichedBOM.Components, 1)
+
+	enrichedComponent := (*enrichedBOM.Components)[0]
+	assert.Nil(t, enrichedComponent.ExternalReferences)
+}
+
+func TestEnrichSBOM_ErrorFetchingScorecard(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	mockPackageData := `{"JSON200": {"RepositoryUrl": "https://example.com/repository"}}`
+	httpmock.RegisterResponder("GET", `=~^https://packages.ecosyste.ms/api/v1/registries`,
+		httpmock.NewStringResponder(http.StatusOK, mockPackageData))
+
+	httpmock.RegisterResponder("GET", "https://api.securityscorecards.dev/projects/example.com/repository",
+		httpmock.NewErrorResponder(assert.AnError))
+
+	httpmock.RegisterNoResponder(func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("unexpected HTTP request: " + req.URL.String())
+	})
+
+	bom := cdx.NewBOM()
+	bom.Components = &[]cdx.Component{
+		{
+			PackageURL: "pkg:/example",
+		},
+	}
+
+	enrichedBOM := EnrichSBOM(bom)
+
+	assert.NotNil(t, enrichedBOM.Components)
+	assert.Len(t, *enrichedBOM.Components, 1)
+
+	enrichedComponent := (*enrichedBOM.Components)[0]
+	assert.Nil(t, enrichedComponent.ExternalReferences)
+}


### PR DESCRIPTION
Currently this just adds an external reference when it finds the project has available scorecard data. Looking into whether or how best to add the score to the BOM as well.