### PR TITLE
refactor: move reading of input to utils package

### DIFF
--- a/internal/commands/ecosystems/enrich.go
+++ b/internal/commands/ecosystems/enrich.go
@@ -1,11 +1,10 @@
 package ecosystems
 
 import (
-	"bufio"
 	"bytes"
-	"io"
 	"os"
 
+	"github.com/snyk/parlay/internal/utils"
 	"github.com/snyk/parlay/lib/ecosystems"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
@@ -19,15 +18,9 @@ func NewEnrichCommand(logger zerolog.Logger) *cobra.Command {
 		Short: "Enrich an SBOM with ecosyste.ms data",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			var err error
-			var b []byte
-			if args[0] == "-" {
-				b, err = io.ReadAll(bufio.NewReader(os.Stdin))
-			} else {
-				b, err = os.ReadFile(args[0])
-			}
+			b, err := utils.GetUserInput(args[0], os.Stdin)
 			if err != nil {
-				logger.Fatal().Err(err).Msg("Couldn't opened the file")
+				logger.Fatal().Err(err).Msg("Problem reading input")
 			}
 
 			bom := new(cdx.BOM)

--- a/internal/commands/snyk/enrich.go
+++ b/internal/commands/snyk/enrich.go
@@ -1,11 +1,10 @@
 package snyk
 
 import (
-	"bufio"
 	"bytes"
-	"io"
 	"os"
 
+	"github.com/snyk/parlay/internal/utils"
 	"github.com/snyk/parlay/lib/snyk"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
@@ -19,15 +18,9 @@ func NewEnrichCommand(logger zerolog.Logger) *cobra.Command {
 		Short: "Enrich an SBOM with Snyk data",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			var err error
-			var b []byte
-			if args[0] == "-" {
-				b, err = io.ReadAll(bufio.NewReader(os.Stdin))
-			} else {
-				b, err = os.ReadFile(args[0])
-			}
+			b, err := utils.GetUserInput(args[0], os.Stdin)
 			if err != nil {
-				logger.Fatal().Err(err).Msg("Problem reading file")
+				logger.Fatal().Err(err).Msg("Problem reading input")
 			}
 
 			bom := new(cdx.BOM)

--- a/internal/utils/input.go
+++ b/internal/utils/input.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+// GetUserInput will open and read from the given filename. If filename is
+// "-", it will read from the given file instead.
+func GetUserInput(filename string, file io.Reader) (b []byte, err error) {
+	if filename != "-" {
+		file, err = os.Open(filename)
+		if err != nil {
+			return nil, fmt.Errorf("could not open file: %w", err)
+		}
+	}
+
+	b, err = io.ReadAll(file)
+	if err != nil {
+		return nil, fmt.Errorf("could not read file: %w", err)
+	}
+
+	if len(b) == 0 {
+		return nil, errors.New("no input given")
+	}
+
+	return b, nil
+}

--- a/internal/utils/input_test.go
+++ b/internal/utils/input_test.go
@@ -1,0 +1,58 @@
+package utils
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetUserInput_File(t *testing.T) {
+	in := []byte("foo")
+	f := writeToTempFile(t, in)
+
+	b, err := GetUserInput(f.Name(), nil)
+
+	assert.NoError(t, err)
+	assert.Equal(t, in, b)
+}
+
+func TestGetUserInput_BadFile(t *testing.T) {
+	b, err := GetUserInput("notafile", nil)
+
+	assert.Nil(t, b)
+	assert.ErrorContains(t, err, "could not open file")
+}
+
+func TestGetUserInput_Stdin(t *testing.T) {
+	in := []byte("bar")
+
+	b, err := GetUserInput("-", bytes.NewReader(in))
+
+	assert.NoError(t, err)
+	assert.Equal(t, in, b)
+}
+
+func TestGetUserInput_NoContent(t *testing.T) {
+	in := new([]byte)
+
+	b, err := GetUserInput("-", bytes.NewReader(*in))
+
+	assert.ErrorContains(t, err, "no input given")
+	assert.Nil(t, b)
+}
+
+func writeToTempFile(t *testing.T, b []byte) *os.File {
+	t.Helper()
+
+	f, err := os.CreateTemp("", "tmpfile-")
+	require.NoError(t, err)
+
+	n, err := f.Write(b)
+	require.Equal(t, len(b), n)
+	require.NoError(t, err)
+
+	return f
+}


### PR DESCRIPTION
Getting feet wet. This refactors the filename/stdin behaviour in `enrich` commands and moves the logic to a common `utils` package, with tests for test coverage.