### PR TITLE
feat: add SPDX support to ecosystems enrich

### DIFF
--- a/lib/ecosystems/enrich.go
+++ b/lib/ecosystems/enrich.go
@@ -18,6 +18,7 @@ package ecosystems
 
 import (
 	cdx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/spdx/tools-golang/spdx"
 
 	"github.com/snyk/parlay/lib/sbom"
 )
@@ -26,6 +27,8 @@ func EnrichSBOM(doc *sbom.SBOMDocument) *sbom.SBOMDocument {
 	switch bom := doc.BOM.(type) {
 	case *cdx.BOM:
 		enrichCDX(bom)
+	case *spdx.Document:
+		enrichSPDX(bom)
 	}
 	return doc
 }

--- a/lib/ecosystems/enrich_cyclonedx.go
+++ b/lib/ecosystems/enrich_cyclonedx.go
@@ -1,3 +1,19 @@
+/*
+ * © 2023 Snyk Limited All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ecosystems
 
 import (
@@ -13,29 +29,29 @@ import (
 type cdxEnricher = func(cdx.Component, packages.Package) cdx.Component
 
 var cdxEnrichers = []cdxEnricher{
-	enrichDescription,
-	enrichLicense,
-	enrichHomepage,
-	enrichRegistryURL,
-	enrichRepositoryURL,
-	enrichDocumentationURL,
-	enrichFirstReleasePublishedAt,
-	enrichLatestReleasePublishedAt,
-	enrichRepoArchived,
-	enrichLocation,
-	enrichTopics,
-	enrichAuthor,
-	enrichSupplier,
+	enrichCDXDescription,
+	enrichCDXLicense,
+	enrichCDXHomepage,
+	enrichCDXRegistryURL,
+	enrichCDXRepositoryURL,
+	enrichCDXDocumentationURL,
+	enrichCDXFirstReleasePublishedAt,
+	enrichCDXLatestReleasePublishedAt,
+	enrichCDXRepoArchived,
+	enrichCDXLocation,
+	enrichCDXTopics,
+	enrichCDXAuthor,
+	enrichCDXSupplier,
 }
 
-func enrichDescription(component cdx.Component, packageData packages.Package) cdx.Component {
+func enrichCDXDescription(component cdx.Component, packageData packages.Package) cdx.Component {
 	if packageData.Description != nil {
 		component.Description = *packageData.Description
 	}
 	return component
 }
 
-func enrichLicense(component cdx.Component, packageData packages.Package) cdx.Component {
+func enrichCDXLicense(component cdx.Component, packageData packages.Package) cdx.Component {
 	if packageData.NormalizedLicenses != nil {
 		if len(packageData.NormalizedLicenses) > 0 {
 			expression := packageData.NormalizedLicenses[0]
@@ -75,23 +91,23 @@ func enrichProperty(component cdx.Component, name string, value string) cdx.Comp
 	return component
 }
 
-func enrichHomepage(component cdx.Component, packageData packages.Package) cdx.Component {
+func enrichCDXHomepage(component cdx.Component, packageData packages.Package) cdx.Component {
 	return enrichExternalReference(component, packageData, packageData.Homepage, cdx.ERTypeWebsite)
 }
 
-func enrichRegistryURL(component cdx.Component, packageData packages.Package) cdx.Component {
+func enrichCDXRegistryURL(component cdx.Component, packageData packages.Package) cdx.Component {
 	return enrichExternalReference(component, packageData, packageData.RegistryUrl, cdx.ERTypeDistribution)
 }
 
-func enrichRepositoryURL(component cdx.Component, packageData packages.Package) cdx.Component {
+func enrichCDXRepositoryURL(component cdx.Component, packageData packages.Package) cdx.Component {
 	return enrichExternalReference(component, packageData, packageData.RepositoryUrl, cdx.ERTypeVCS)
 }
 
-func enrichDocumentationURL(component cdx.Component, packageData packages.Package) cdx.Component {
+func enrichCDXDocumentationURL(component cdx.Component, packageData packages.Package) cdx.Component {
 	return enrichExternalReference(component, packageData, packageData.DocumentationUrl, cdx.ERTypeDocumentation)
 }
 
-func enrichFirstReleasePublishedAt(component cdx.Component, packageData packages.Package) cdx.Component {
+func enrichCDXFirstReleasePublishedAt(component cdx.Component, packageData packages.Package) cdx.Component {
 	if packageData.FirstReleasePublishedAt == nil {
 		return component
 	}
@@ -99,7 +115,7 @@ func enrichFirstReleasePublishedAt(component cdx.Component, packageData packages
 	return enrichProperty(component, "ecosystems:first_release_published_at", timestamp)
 }
 
-func enrichLatestReleasePublishedAt(component cdx.Component, packageData packages.Package) cdx.Component {
+func enrichCDXLatestReleasePublishedAt(component cdx.Component, packageData packages.Package) cdx.Component {
 	if packageData.LatestReleasePublishedAt == nil {
 		return component
 	}
@@ -107,7 +123,7 @@ func enrichLatestReleasePublishedAt(component cdx.Component, packageData package
 	return enrichProperty(component, "ecosystems:latest_release_published_at", timestamp)
 }
 
-func enrichRepoArchived(component cdx.Component, packageData packages.Package) cdx.Component {
+func enrichCDXRepoArchived(component cdx.Component, packageData packages.Package) cdx.Component {
 	if packageData.RepoMetadata != nil {
 		if archived, ok := (*packageData.RepoMetadata)["archived"].(bool); ok && archived {
 			return enrichProperty(component, "ecosystems:repository_archived", "true")
@@ -116,7 +132,7 @@ func enrichRepoArchived(component cdx.Component, packageData packages.Package) c
 	return component
 }
 
-func enrichLocation(component cdx.Component, packageData packages.Package) cdx.Component {
+func enrichCDXLocation(component cdx.Component, packageData packages.Package) cdx.Component {
 	if packageData.RepoMetadata != nil {
 		meta := *packageData.RepoMetadata
 		if ownerRecord, ok := meta["owner_record"].(map[string]interface{}); ok {
@@ -128,7 +144,7 @@ func enrichLocation(component cdx.Component, packageData packages.Package) cdx.C
 	return component
 }
 
-func enrichAuthor(component cdx.Component, packageData packages.Package) cdx.Component {
+func enrichCDXAuthor(component cdx.Component, packageData packages.Package) cdx.Component {
 	if packageData.RepoMetadata != nil {
 		meta := *packageData.RepoMetadata
 		if ownerRecord, ok := meta["owner_record"].(map[string]interface{}); ok {
@@ -141,7 +157,7 @@ func enrichAuthor(component cdx.Component, packageData packages.Package) cdx.Com
 	return component
 }
 
-func enrichSupplier(component cdx.Component, packageData packages.Package) cdx.Component {
+func enrichCDXSupplier(component cdx.Component, packageData packages.Package) cdx.Component {
 	if packageData.RepoMetadata != nil {
 		meta := *packageData.RepoMetadata
 		if ownerRecord, ok := meta["owner_record"].(map[string]interface{}); ok {
@@ -161,7 +177,7 @@ func enrichSupplier(component cdx.Component, packageData packages.Package) cdx.C
 	return component
 }
 
-func enrichTopics(component cdx.Component, packageData packages.Package) cdx.Component {
+func enrichCDXTopics(component cdx.Component, packageData packages.Package) cdx.Component {
 	if packageData.RepoMetadata != nil {
 		meta := *packageData.RepoMetadata
 

--- a/lib/ecosystems/enrich_spdx.go
+++ b/lib/ecosystems/enrich_spdx.go
@@ -1,0 +1,90 @@
+/*
+ * © 2023 Snyk Limited All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ecosystems
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/package-url/packageurl-go"
+	"github.com/spdx/tools-golang/spdx"
+	"github.com/spdx/tools-golang/spdx/v2/v2_3"
+
+	"github.com/snyk/parlay/ecosystems/packages"
+)
+
+func enrichSPDX(bom *spdx.Document) {
+	packages := bom.Packages
+
+	for _, pkg := range packages {
+		purl, err := extractPurl(pkg)
+		if err != nil {
+			continue
+		}
+
+		resp, err := GetPackageData(*purl)
+		if err != nil {
+			continue
+		}
+
+		pkgData := resp.JSON200
+		if pkgData == nil {
+			continue
+		}
+
+		enrichSPDXDescription(pkg, pkgData)
+		enrichSPDXLicense(pkg, pkgData)
+		enrichSPDXHomepage(pkg, pkgData)
+	}
+}
+
+func extractPurl(pkg *v2_3.Package) (*packageurl.PackageURL, error) {
+	for _, ref := range pkg.PackageExternalReferences {
+		if ref.RefType != "purl" {
+			continue
+		}
+		purl, err := packageurl.FromString(ref.Locator)
+		if err != nil {
+			return nil, err
+		}
+		return &purl, nil
+	}
+	return nil, errors.New("no purl found on SPDX package")
+}
+
+func enrichSPDXLicense(pkg *v2_3.Package, data *packages.Package) {
+	if len(data.NormalizedLicenses) == 1 {
+		pkg.PackageLicenseConcluded = data.NormalizedLicenses[0]
+	} else if len(data.NormalizedLicenses) > 1 {
+		pkg.PackageLicenseConcluded = fmt.Sprintf("(%s)", strings.Join(data.NormalizedLicenses, " OR "))
+	}
+}
+
+func enrichSPDXHomepage(pkg *v2_3.Package, data *packages.Package) {
+	if data.Homepage == nil {
+		return
+	}
+	pkg.PackageHomePage = *data.Homepage
+}
+
+func enrichSPDXDescription(pkg *v2_3.Package, data *packages.Package) {
+	if data.Description == nil {
+		return
+	}
+	pkg.PackageDescription = *data.Description
+}

--- a/lib/ecosystems/enrich_spdx_test.go
+++ b/lib/ecosystems/enrich_spdx_test.go
@@ -1,0 +1,75 @@
+/*
+ * © 2023 Snyk Limited All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ecosystems
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/spdx/tools-golang/spdx/v2/common"
+	"github.com/spdx/tools-golang/spdx/v2/v2_3"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/parlay/lib/sbom"
+)
+
+func TestEnrichSBOM_SPDX(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("GET", `=~^https://packages.ecosyste.ms/api/v1/registries`,
+		func(req *http.Request) (*http.Response, error) {
+			return httpmock.NewJsonResponse(200, map[string]interface{}{
+				"description": "description",
+				"normalized_licenses": []string{
+					"BSD-3-Clause",
+				},
+				"homepage": "https://github.com/spdx/tools-golang",
+			})
+		})
+
+	bom := &v2_3.Document{
+		Packages: []*v2_3.Package{
+			{
+				PackageSPDXIdentifier: "pkg:golang/github.com/spdx/tools-golang@v0.5.2",
+				PackageName:           "github.com/spdx/tools-golang",
+				PackageVersion:        "v0.5.2",
+				PackageExternalReferences: []*v2_3.PackageExternalReference{
+					{
+						Category: common.CategoryPackageManager,
+						RefType:  "purl",
+						Locator:  "pkg:golang/github.com/spdx/tools-golang@v0.5.2",
+					},
+				},
+			},
+		},
+	}
+	doc := &sbom.SBOMDocument{BOM: bom}
+
+	EnrichSBOM(doc)
+
+	pkgs := bom.Packages
+
+	assert.Equal(t, "description", pkgs[0].PackageDescription)
+	assert.Equal(t, "BSD-3-Clause", pkgs[0].PackageLicenseConcluded)
+	assert.Equal(t, "https://github.com/spdx/tools-golang", pkgs[0].PackageHomePage)
+
+	httpmock.GetTotalCallCount()
+	calls := httpmock.GetCallCountInfo()
+	assert.Equal(t, len(pkgs), calls[`GET =~^https://packages.ecosyste.ms/api/v1/registries`])
+}


### PR DESCRIPTION
This adds SPDX support to the `ecosystems enrich` command.

```bash
$ parlay ecosystems enrich testing/sbom.spdx-2.3.json | jq ".packages[1]"
{
  "name": "debug",
  "SPDXID": "SPDXRef-2-debug-1.0.5",
  "versionInfo": "1.0.5",
  "downloadLocation": "NOASSERTION",
  "filesAnalyzed": true,
  "homepage": "https://github.com/debug-js/debug",
  "licenseConcluded": "MIT",
  "copyrightText": "NOASSERTION",
  "description": "Lightweight debugging utility for Node.js and the browser",
  "externalRefs": [
    {
      "referenceCategory": "PACKAGE-MANAGER",
      "referenceType": "purl",
      "referenceLocator": "pkg:npm/debug@1.0.5"
    }
  ]
}
```