### PR TITLE
Update email address for reporting code of conduct issues

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-`daniel.appelquist <at> snyk.io`.
+`oss-conduct-reports@snyk.io`.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
This PR changes the email address for reporting code of conduct issues to the newly created oss-conduct-reports@snyk.io address.