### PR TITLE
fix: golang purl resolution (snyk#34)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,7 @@ dist
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
+# IDE configs
+.idea
+
 /parlay

--- a/lib/ecosystems/package.go
+++ b/lib/ecosystems/package.go
@@ -65,22 +65,21 @@ func purlToEcosystemsRegistry(purl packageurl.PackageURL) string {
 }
 
 func purlToEcosystemsName(purl packageurl.PackageURL) string {
+	if purl.Namespace == "" {
+		return purl.Name
+	}
+
 	var name string
 	// npm names in the ecosyste.ms API include the purl namespace
 	// followed by a / and are url encoded. Other package managers
 	// appear to separate the purl namespace and name with a :
-	if purl.Type == "npm" {
-		if purl.Namespace != "" {
-			name = url.QueryEscape(fmt.Sprintf("%s/%s", purl.Namespace, purl.Name))
-		} else {
-			name = purl.Name
-		}
-	} else {
-		if purl.Namespace != "" {
-			name = fmt.Sprintf("%s:%s", purl.Namespace, purl.Name)
-		} else {
-			name = purl.Name
-		}
+	switch purl.Type {
+	case "npm":
+		name = url.QueryEscape(fmt.Sprintf("%s/%s", purl.Namespace, purl.Name))
+	case "golang":
+		name = fmt.Sprintf("%s/%s", purl.Namespace, purl.Name)
+	default:
+		name = fmt.Sprintf("%s:%s", purl.Namespace, purl.Name)
 	}
 	return name
 }

--- a/lib/ecosystems/package_test.go
+++ b/lib/ecosystems/package_test.go
@@ -111,6 +111,20 @@ func TestPurlToEcosystemsName(t *testing.T) {
 			purlStr:      "pkg:maven/my-artifact",
 			expectedName: "my-artifact",
 		},
+		{
+			// Test case 5: When the package manager type is "golang"
+			// and the namespace is not empty, the function should return
+			// a string in the form of "<namespace>/<name>"
+			purlStr:      "pkg:golang/example.com/foo/bar@v1.5.0",
+			expectedName: "example.com/foo/bar",
+		},
+		{
+			// Test case 6: When the package manager type is "golang"
+			// and the namespace has lots of weird characters, make sure
+			// they get filtered properly
+			purlStr:      "pkg:golang/example.com/f.o_o/ba~r",
+			expectedName: "example.com/f.o_o/ba~r",
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
Ecosyste.ms appears to handle package URLs inconsistently depending on which type of package is involved. I added another case for Golang packages, since those didn't resolve properly with the default.