### PR TITLE
feat: add ecosystems support for docker, swift

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/edoardottt/depsdev v0.0.3
 	github.com/google/uuid v1.3.0
 	github.com/jarcoal/httpmock v1.3.0
-	github.com/package-url/packageurl-go v0.1.1-0.20220428063043-89078438f170
+	github.com/package-url/packageurl-go v0.1.2-0.20230717211154-3587d8c2829e
 	github.com/remeh/sizedwaitgroup v1.0.0
 	github.com/rs/zerolog v1.29.1
 	github.com/spdx/tools-golang v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -168,8 +168,8 @@ github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/maxatome/go-testdeep v1.12.0 h1:Ql7Go8Tg0C1D/uMMX59LAoYK7LffeJQ6X2T04nTH68g=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/package-url/packageurl-go v0.1.1-0.20220428063043-89078438f170 h1:DiLBVp4DAcZlBVBEtJpNWZpZVq0AEeCY7Hqk8URVs4o=
-github.com/package-url/packageurl-go v0.1.1-0.20220428063043-89078438f170/go.mod h1:uQd4a7Rh3ZsVg5j0lNyAfyxIeGde9yrlhjF78GzeW0c=
+github.com/package-url/packageurl-go v0.1.2-0.20230717211154-3587d8c2829e h1:h/TWC+mVfoco4qhPEsaxkdwymlTaDe/BGnzljU8SIPw=
+github.com/package-url/packageurl-go v0.1.2-0.20230717211154-3587d8c2829e/go.mod h1:uQd4a7Rh3ZsVg5j0lNyAfyxIeGde9yrlhjF78GzeW0c=
 github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=
 github.com/pelletier/go-toml/v2 v2.0.6/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/lib/ecosystems/package.go
+++ b/lib/ecosystems/package.go
@@ -50,7 +50,7 @@ func GetPackageData(purl packageurl.PackageURL) (*packages.GetRegistryPackageRes
 
 func purlToEcosystemsRegistry(purl packageurl.PackageURL) string {
 	return map[string]string{
-		packageurl.TypeApk:       "alpine",
+		packageurl.TypeApk:       "alpine-edge",
 		packageurl.TypeCargo:     "crates.io",
 		packageurl.TypeCocoapods: "cocoapod.org",
 		packageurl.TypeComposer:  "packagist.org",

--- a/lib/ecosystems/package.go
+++ b/lib/ecosystems/package.go
@@ -50,17 +50,19 @@ func GetPackageData(purl packageurl.PackageURL) (*packages.GetRegistryPackageRes
 
 func purlToEcosystemsRegistry(purl packageurl.PackageURL) string {
 	return map[string]string{
-		"npm":       "npmjs.org",
-		"golang":    "proxy.golang.org",
-		"nuget":     "nuget.org",
-		"hex":       "hex.pm",
-		"maven":     "repo1.maven.org",
-		"pypi":      "pypi.org",
-		"composer":  "packagist.org",
-		"gem":       "rubygems.org",
-		"cargo":     "crates.io",
-		"cocoapods": "cocoapod.org",
-		"apk":       "alpine",
+		packageurl.TypeApk:       "alpine",
+		packageurl.TypeCargo:     "crates.io",
+		packageurl.TypeCocoapods: "cocoapod.org",
+		packageurl.TypeComposer:  "packagist.org",
+		packageurl.TypeDocker:    "hub.docker.com",
+		packageurl.TypeGem:       "rubygems.org",
+		packageurl.TypeGolang:    "proxy.golang.org",
+		packageurl.TypeHex:       "hex.pm",
+		packageurl.TypeMaven:     "repo1.maven.org",
+		packageurl.TypeNPM:       "npmjs.org",
+		packageurl.TypeNuget:     "nuget.org",
+		packageurl.TypePyPi:      "pypi.org",
+		packageurl.TypeSwift:     "swiftpackageindex.com",
 	}[purl.Type]
 }
 

--- a/lib/ecosystems/package.go
+++ b/lib/ecosystems/package.go
@@ -67,21 +67,28 @@ func purlToEcosystemsRegistry(purl packageurl.PackageURL) string {
 }
 
 func purlToEcosystemsName(purl packageurl.PackageURL) string {
+	name := purl.Name
+
 	if purl.Namespace == "" {
-		return purl.Name
+		return name
 	}
 
-	var name string
-	// npm names in the ecosyste.ms API include the purl namespace
-	// followed by a / and are url encoded. Other package managers
-	// appear to separate the purl namespace and name with a :
 	switch purl.Type {
-	case "npm":
-		name = url.QueryEscape(fmt.Sprintf("%s/%s", purl.Namespace, purl.Name))
-	case "golang":
-		name = fmt.Sprintf("%s/%s", purl.Namespace, purl.Name)
+	// Most ecosystems require the package to be identified by the namespace
+	// and name separated by a forward slash "/".
 	default:
+		name = fmt.Sprintf("%s/%s", purl.Namespace, purl.Name)
+
+	// Ecosystem maven requires the group ID and artifact ID to be separated
+	// by a colon ":",
+	case packageurl.TypeMaven:
 		name = fmt.Sprintf("%s:%s", purl.Namespace, purl.Name)
+
+	// Ecosystem npm requires the combination of namespace and name to
+	// be URL-encoded, including the separator.
+	case packageurl.TypeNPM:
+		name = url.QueryEscape(fmt.Sprintf("%s/%s", purl.Namespace, purl.Name))
 	}
+
 	return name
 }

--- a/lib/ecosystems/package_test.go
+++ b/lib/ecosystems/package_test.go
@@ -63,7 +63,9 @@ func TestPurlToEcosystemsRegistry(t *testing.T) {
 		{"pkg:gem/rspec-core@3.10.1", "rubygems.org"},
 		{"pkg:cargo/rand@0.8.4", "crates.io"},
 		{"pkg:cocoapods/Firebase@7.0.0", "cocoapod.org"},
-		{"pkg:apk/curl@7.79.1-r0", "alpine"},
+		{"pkg:apk/alpine/curl@7.79.1-r0", "alpine"},
+		{"pkg:swift/github.com/yonaskolb/XcodeGen@2.34.0", "swiftpackageindex.com"},
+		{"pkg:docker/library%2Falpine", "hub.docker.com"},
 	}
 
 	for _, tc := range testCases {

--- a/lib/ecosystems/package_test.go
+++ b/lib/ecosystems/package_test.go
@@ -100,14 +100,14 @@ func TestPurlToEcosystemsName(t *testing.T) {
 			expectedName: "my-package",
 		},
 		{
-			// Test case 3: When the package manager type is not "npm"
+			// Test case 3: When the package manager type is "maven"
 			// and the namespace is not empty, the function should return
 			// a string in the form of "<namespace>:<name>"
 			purlStr:      "pkg:maven/my-group:my-artifact",
 			expectedName: "my-group:my-artifact",
 		},
 		{
-			// Test case 4: When the package manager type is not "npm"
+			// Test case 4: When the package manager type is "maven"
 			// and the namespace is empty, the function should return
 			// the package name as is.
 			purlStr:      "pkg:maven/my-artifact",
@@ -126,6 +126,11 @@ func TestPurlToEcosystemsName(t *testing.T) {
 			// they get filtered properly
 			purlStr:      "pkg:golang/example.com/f.o_o/ba~r",
 			expectedName: "example.com/f.o_o/ba~r",
+		},
+		{
+			// Test case 7: When the package manager type is "swift"
+			purlStr:      "pkg:swift/github.com/yonaskolb/XcodeGen@1",
+			expectedName: "github.com/yonaskolb/XcodeGen",
 		},
 	}
 

--- a/lib/ecosystems/package_test.go
+++ b/lib/ecosystems/package_test.go
@@ -63,7 +63,7 @@ func TestPurlToEcosystemsRegistry(t *testing.T) {
 		{"pkg:gem/rspec-core@3.10.1", "rubygems.org"},
 		{"pkg:cargo/rand@0.8.4", "crates.io"},
 		{"pkg:cocoapods/Firebase@7.0.0", "cocoapod.org"},
-		{"pkg:apk/alpine/curl@7.79.1-r0", "alpine"},
+		{"pkg:apk/alpine/curl@7.79.1-r0", "alpine-edge"},
 		{"pkg:swift/github.com/yonaskolb/XcodeGen@2.34.0", "swiftpackageindex.com"},
 		{"pkg:docker/library%2Falpine", "hub.docker.com"},
 	}


### PR DESCRIPTION
This adds support for purl types `docker` and `swift` when enriching via ecosyste.ms.

It also fixes an issue with the package name mapping logic, where the `maven` logic was applied to most purl types.

It also resolves `apk` purls to repository `alpine-edge`, since `alpine` on its own is not complete.

<img width="820" alt="image" src="https://github.com/snyk/parlay/assets/1739114/a54a7752-2848-4195-a363-c615869074f0">
