### PR TITLE
Add go to the Snyk docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ The various services used to enrich the SBOM data have data for a subset of purl
 * `composer`
 * `deb`
 * `gem`
+* `golang`
 * `hex`
 * `maven`
 * `npm`


### PR DESCRIPTION
The underlying API now supports golang purl types. Updating the docs.