### PR TITLE
chore: add secrets scanning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+workflows:
+  version: 2
+  CICD:
+    jobs:
+      - prodsec/secrets-scan:
+          name: Scan repository for secrets
+          context:
+            - snyk-bot-slack
+          channel: team-link-pipeline-info
+          filters:
+            branches:
+              ignore:
+                - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,8 @@
+version: 2.1
+
+orbs:
+  prodsec: snyk/prodsec-orb@1.0
+
 workflows:
   version: 2
   CICD:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.16.1
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
- add gitleaks precommit
- add prodsec secrets scanning via circleci as github actions for same are not supported for public repos (see https://snyksec.atlassian.net/wiki/spaces/PRODSEC/pages/1563787412/Secrets+Scanning#3.4.2.-Using-ProdSec-Tools-in-a-GitHub-Action)