### PR TITLE
fix: print debug output for issues during snyk enrich.

### DIFF
--- a/internal/commands/snyk/enrich.go
+++ b/internal/commands/snyk/enrich.go
@@ -27,7 +27,7 @@ func NewEnrichCommand(logger zerolog.Logger) *cobra.Command {
 				logger.Fatal().Err(err).Msg("Failed to read SBOM input")
 			}
 
-			snyk.EnrichSBOM(doc)
+			snyk.EnrichSBOM(doc, logger)
 
 			if err := doc.Encode(os.Stdout); err != nil {
 				logger.Fatal().Err(err).Msg("Failed to encode new SBOM")

--- a/lib/snyk/enrich.go
+++ b/lib/snyk/enrich.go
@@ -18,17 +18,18 @@ package snyk
 
 import (
 	cdx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/rs/zerolog"
 	"github.com/spdx/tools-golang/spdx"
 
 	"github.com/snyk/parlay/lib/sbom"
 )
 
-func EnrichSBOM(doc *sbom.SBOMDocument) *sbom.SBOMDocument {
+func EnrichSBOM(doc *sbom.SBOMDocument, logger zerolog.Logger) *sbom.SBOMDocument {
 	switch bom := doc.BOM.(type) {
 	case *cdx.BOM:
-		enrichCycloneDX(bom)
+		enrichCycloneDX(bom, logger)
 	case *spdx.Document:
-		enrichSPDX(bom)
+		enrichSPDX(bom, logger)
 	}
 
 	return doc

--- a/lib/snyk/enrich_test.go
+++ b/lib/snyk/enrich_test.go
@@ -5,6 +5,7 @@ import (
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
 	"github.com/jarcoal/httpmock"
+	"github.com/rs/zerolog"
 	spdx "github.com/spdx/tools-golang/spdx/v2/common"
 	spdx_2_3 "github.com/spdx/tools-golang/spdx/v2/v2_3"
 	"github.com/stretchr/testify/assert"
@@ -27,8 +28,9 @@ func TestEnrichSBOM_CycloneDXWithVulnerabilities(t *testing.T) {
 		},
 	}
 	doc := &sbom.SBOMDocument{BOM: bom}
+	logger := zerolog.Nop()
 
-	EnrichSBOM(doc)
+	EnrichSBOM(doc, logger)
 
 	assert.NotNil(t, bom.Vulnerabilities)
 	assert.Len(t, *bom.Vulnerabilities, 1)
@@ -52,8 +54,9 @@ func TestEnrichSBOM_CycloneDXWithoutVulnerabilities(t *testing.T) {
 		},
 	}
 	doc := &sbom.SBOMDocument{BOM: bom}
+	logger := zerolog.Nop()
 
-	EnrichSBOM(doc)
+	EnrichSBOM(doc, logger)
 
 	assert.Nil(t, bom.Vulnerabilities, "should not extend vulnerabilities if there are none")
 }
@@ -79,8 +82,9 @@ func TestEnrichSBOM_SPDXWithVulnerabilities(t *testing.T) {
 		},
 	}
 	doc := &sbom.SBOMDocument{BOM: bom}
+	logger := zerolog.Nop()
 
-	EnrichSBOM(doc)
+	EnrichSBOM(doc, logger)
 
 	vulnRef := bom.Packages[0].PackageExternalReferences[1]
 	assert.Equal(t, "SECURITY", vulnRef.Category)


### PR DESCRIPTION
This passes the logger instance down to `snyk enrich` functions to add meaningful debug output.

Closes #47.

```bash
SNYK_TOKEN=asdf ./parlay snyk enrich testing/sbom.spdx-2.3.json
7:00AM ERR Failed to fetch vulnerabilities for package. error="Failed to get user info (401 Unauthorized)" purl=pkg:npm/package-file-basic@1.0.0
7:00AM ERR Failed to fetch vulnerabilities for package. error="Failed to get user info (401 Unauthorized)" purl=pkg:npm/minimatch@3.0.0
7:00AM ERR Failed to fetch vulnerabilities for package. error="Failed to get user info (401 Unauthorized)" purl=pkg:npm/debug@1.0.5
7:00AM ERR Failed to fetch vulnerabilities for package. error="Failed to get user info (401 Unauthorized)" purl=pkg:npm/ms@2.0.0
7:00AM ERR Failed to fetch vulnerabilities for package. error="Failed to get user info (401 Unauthorized)" purl=pkg:npm/balanced-match@1.0.2
7:00AM ERR Failed to fetch vulnerabilities for package. error="Failed to get user info (401 Unauthorized)" purl=pkg:npm/concat-map@0.0.1
7:00AM ERR Failed to fetch vulnerabilities for package. error="Failed to get user info (401 Unauthorized)" purl=pkg:npm/brace-expansion@1.1.11
{"spdxVersion":"SPDX-2.3",...
```