### PR TITLE
fix: user info

### DIFF
--- a/internal/commands/snyk/packages.go
+++ b/internal/commands/snyk/packages.go
@@ -20,11 +20,33 @@ func NewPackageCommand(logger zerolog.Logger) *cobra.Command {
 			if err != nil {
 				logger.Fatal().Err(err).Msg("Not a valid purl")
 			}
-			logger.Debug().Str("purl", args[0]).Msg("Looking up package vulnerabilities from Snyk")
-			resp, err := snyk.GetPackageVulnerabilities(purl)
+
+			logger.
+				Debug().
+				Str("purl", args[0]).
+				Msg("Looking up package vulnerabilities from Snyk")
+
+			auth, err := snyk.AuthFromToken(snyk.APIToken())
+			if err != nil {
+				logger.
+					Fatal().
+					Err(err).
+					Msg("Failed to get API credentials.")
+			}
+
+			orgID, err := snyk.SnykOrgID(auth)
+			if err != nil {
+				logger.
+					Fatal().
+					Err(err).
+					Msg("Failed to look up user info.")
+			}
+
+			resp, err := snyk.GetPackageVulnerabilities(&purl, auth, orgID)
 			if err != nil {
 				logger.Fatal().Err(err).Msg("An error occurred")
 			}
+
 			fmt.Print(string(resp.Body))
 		},
 	}

--- a/lib/snyk/package.go
+++ b/lib/snyk/package.go
@@ -18,11 +18,9 @@ package snyk
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"os"
 
 	"github.com/deepmap/oapi-codegen/pkg/securityprovider"
+	"github.com/google/uuid"
 	"github.com/package-url/packageurl-go"
 
 	"github.com/snyk/parlay/snyk/issues"
@@ -31,29 +29,14 @@ import (
 const snykServer = "https://api.snyk.io/rest"
 const version = "2023-04-28"
 
-func GetPackageVulnerabilities(purl packageurl.PackageURL) (*issues.FetchIssuesPerPurlResponse, error) {
-	token := os.Getenv("SNYK_TOKEN")
-	if token == "" {
-		return nil, errors.New("Must provide a SNYK_TOKEN environment variable")
-	}
-
-	auth, err := securityprovider.NewSecurityProviderApiKey("header", "Authorization", fmt.Sprintf("token %s", token))
-	if err != nil {
-		return nil, err
-	}
-
-	org, err := getSnykOrg(auth)
-	if err != nil {
-		return nil, err
-	}
-
+func GetPackageVulnerabilities(purl *packageurl.PackageURL, auth *securityprovider.SecurityProviderApiKey, orgID *uuid.UUID) (*issues.FetchIssuesPerPurlResponse, error) {
 	client, err := issues.NewClientWithResponses(snykServer, issues.WithRequestEditorFn(auth.Intercept))
 	if err != nil {
 		return nil, err
 	}
 
 	params := issues.FetchIssuesPerPurlParams{Version: version}
-	resp, err := client.FetchIssuesPerPurlWithResponse(context.Background(), *org, purl.ToString(), &params)
+	resp, err := client.FetchIssuesPerPurlWithResponse(context.Background(), *orgID, purl.ToString(), &params)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/snyk/self.go
+++ b/lib/snyk/self.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/deepmap/oapi-codegen/pkg/securityprovider"
 	"github.com/google/uuid"
@@ -37,7 +38,7 @@ type selfDocument struct {
 	}
 }
 
-func getSnykOrg(auth *securityprovider.SecurityProviderApiKey) (*uuid.UUID, error) {
+func SnykOrgID(auth *securityprovider.SecurityProviderApiKey) (*uuid.UUID, error) {
 	experimental, err := users.NewClientWithResponses(snykServer, users.WithRequestEditorFn(auth.Intercept))
 	if err != nil {
 		return nil, err
@@ -63,4 +64,21 @@ func getSnykOrg(auth *securityprovider.SecurityProviderApiKey) (*uuid.UUID, erro
 	}
 
 	return nil, errors.New("Failed to get org ID.")
+}
+
+func AuthFromToken(token string) (*securityprovider.SecurityProviderApiKey, error) {
+	if token == "" {
+		return nil, errors.New("Must provide a SNYK_TOKEN environment variable")
+	}
+
+	auth, err := securityprovider.NewSecurityProviderApiKey("header", "Authorization", fmt.Sprintf("token %s", token))
+	if err != nil {
+		return nil, err
+	}
+
+	return auth, nil
+}
+
+func APIToken() string {
+	return os.Getenv("SNYK_TOKEN")
 }

--- a/lib/snyk/self_test.go
+++ b/lib/snyk/self_test.go
@@ -17,6 +17,7 @@
 package snyk
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/deepmap/oapi-codegen/pkg/securityprovider"
@@ -26,7 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetSnykOrg(t *testing.T) {
+func TestGetSnykOrg_Success(t *testing.T) {
 	expectedOrg := uuid.MustParse("00000000-0000-0000-0000-000000000000")
 	auth, err := securityprovider.NewSecurityProviderApiKey("header", "name", "value")
 	require.NoError(t, err)
@@ -34,10 +35,25 @@ func TestGetSnykOrg(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 	httpmock.RegisterResponder("GET", "https://api.snyk.io/rest/self",
-		httpmock.NewJsonResponderOrPanic(200, httpmock.File("testdata/self.json")),
+		httpmock.NewJsonResponderOrPanic(http.StatusOK, httpmock.File("testdata/self.json")),
 	)
 
 	actualOrg, err := getSnykOrg(auth)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedOrg, *actualOrg)
+}
+
+func TestGetSnykOrg_Unauthorized(t *testing.T) {
+	auth, err := securityprovider.NewSecurityProviderApiKey("header", "name", "value")
+	require.NoError(t, err)
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	httpmock.RegisterResponder("GET", "https://api.snyk.io/rest/self",
+		httpmock.NewJsonResponderOrPanic(http.StatusUnauthorized, []byte(`{"msg":"unauthorized"}`)),
+	)
+
+	actualOrg, err := getSnykOrg(auth)
+	assert.ErrorContains(t, err, "Failed to get user info (401)")
+	assert.Nil(t, actualOrg)
 }

--- a/lib/snyk/self_test.go
+++ b/lib/snyk/self_test.go
@@ -38,7 +38,7 @@ func TestGetSnykOrg_Success(t *testing.T) {
 		httpmock.NewJsonResponderOrPanic(http.StatusOK, httpmock.File("testdata/self.json")),
 	)
 
-	actualOrg, err := getSnykOrg(auth)
+	actualOrg, err := SnykOrgID(auth)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedOrg, *actualOrg)
 }
@@ -53,7 +53,7 @@ func TestGetSnykOrg_Unauthorized(t *testing.T) {
 		httpmock.NewJsonResponderOrPanic(http.StatusUnauthorized, []byte(`{"msg":"unauthorized"}`)),
 	)
 
-	actualOrg, err := getSnykOrg(auth)
+	actualOrg, err := SnykOrgID(auth)
 	assert.ErrorContains(t, err, "Failed to get user info (401)")
 	assert.Nil(t, actualOrg)
 }


### PR DESCRIPTION
This PR addresses two issues:

* #48: `getSnykOrg` did not return error if request to self endpoint was unsuccessful, resulting in a `nil` pointer UUID
* #46: package vulnerability lookup was making a request to the self endpoint for each package within an SBOM