### PR TITLE
fix: wrong encoding for npm package requests for ecosystem.ms

### DIFF
--- a/lib/ecosystems/package.go
+++ b/lib/ecosystems/package.go
@@ -19,7 +19,6 @@ package ecosystems
 import (
 	"context"
 	"fmt"
-	"net/url"
 
 	"github.com/package-url/packageurl-go"
 
@@ -84,16 +83,10 @@ func purlToEcosystemsName(purl packageurl.PackageURL) string {
 	case packageurl.TypeMaven:
 		name = fmt.Sprintf("%s:%s", purl.Namespace, purl.Name)
 
-	// ecosyste.ms npm requires the combination of namespace and name to
-	// be URL-encoded, including the separator.
-	case packageurl.TypeNPM:
-		name = url.QueryEscape(fmt.Sprintf("%s/%s", purl.Namespace, purl.Name))
-
 	// apk packages are only used by alpine, so the namespace isn't used in the
 	// package name for the ecosyste.ms API
 	case packageurl.TypeApk:
 		break
 	}
-
 	return name
 }

--- a/lib/ecosystems/package_test.go
+++ b/lib/ecosystems/package_test.go
@@ -18,7 +18,6 @@ package ecosystems
 
 import (
 	"fmt"
-	"net/url"
 	"testing"
 
 	"github.com/jarcoal/httpmock"
@@ -90,7 +89,7 @@ func TestPurlToEcosystemsName(t *testing.T) {
 			// and the namespace is not empty, the function should return
 			// a url encoded string in the form of "<namespace>/<name>"
 			purlStr:      "pkg:npm/my-namespace/my-package",
-			expectedName: url.QueryEscape("my-namespace/my-package"),
+			expectedName: "my-namespace/my-package",
 		},
 		{
 			// Test case 2: When the package manager type is "npm"

--- a/lib/ecosystems/package_test.go
+++ b/lib/ecosystems/package_test.go
@@ -88,8 +88,8 @@ func TestPurlToEcosystemsName(t *testing.T) {
 			// Test case 1: When the package manager type is "npm"
 			// and the namespace is not empty, the function should return
 			// a url encoded string in the form of "<namespace>/<name>"
-			purlStr:      "pkg:npm/my-namespace/my-package",
-			expectedName: "my-namespace/my-package",
+			purlStr:      "pkg:npm/%40my-namespace/my-package",
+			expectedName: "@my-namespace/my-package",
 		},
 		{
 			// Test case 2: When the package manager type is "npm"


### PR DESCRIPTION
Remove initial url encoding for `npm` purls which broke ecosystem.ms requests for purls with namespaces