### PR TITLE
feat: more verbose log messages in all commands

### DIFF
--- a/internal/commands/default.go
+++ b/internal/commands/default.go
@@ -48,10 +48,10 @@ func NewDefaultCommand() *cobra.Command {
 
 	cmd.SetVersionTemplate(`{{.Version}}`)
 
-	cmd.AddCommand(ecosystems.NewEcosystemsRootCommand(logger))
-	cmd.AddCommand(snyk.NewSnykRootCommand(logger))
-	cmd.AddCommand(deps.NewDepsRootCommand(logger))
-	cmd.AddCommand(scorecard.NewRootCommand(logger))
+	cmd.AddCommand(ecosystems.NewEcosystemsRootCommand(&logger))
+	cmd.AddCommand(snyk.NewSnykRootCommand(&logger))
+	cmd.AddCommand(deps.NewDepsRootCommand(&logger))
+	cmd.AddCommand(scorecard.NewRootCommand(&logger))
 
 	return &cmd
 }

--- a/internal/commands/deps/repos.go
+++ b/internal/commands/deps/repos.go
@@ -10,7 +10,7 @@ import (
 	"github.com/snyk/parlay/lib/deps"
 )
 
-func NewRepoCommand(logger zerolog.Logger) *cobra.Command {
+func NewRepoCommand(logger *zerolog.Logger) *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "repo <repo>",
 		Short: "Return repo info from deps.dev",
@@ -18,12 +18,14 @@ func NewRepoCommand(logger zerolog.Logger) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			repo, err := deps.GetRepoData(args[0])
 			if err != nil {
-				logger.Fatal().Err(err).Msg("Error retrieving data from deps.dev")
+				logger.Fatal().Err(err).Msg("Failed to retrieve data from deps.dev")
 			}
+
 			repository, err := json.Marshal(repo)
 			if err != nil {
-				logger.Fatal().Err(err).Msg("Error with JSON response from deps.dev")
+				logger.Fatal().Err(err).Msg("Failed to parse response from deps.dev")
 			}
+
 			fmt.Print(string(repository))
 		},
 	}

--- a/internal/commands/deps/root.go
+++ b/internal/commands/deps/root.go
@@ -5,7 +5,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewDepsRootCommand(logger zerolog.Logger) *cobra.Command {
+func NewDepsRootCommand(logger *zerolog.Logger) *cobra.Command {
 	cmd := cobra.Command{
 		Use:                   "deps",
 		Short:                 "Commands for using parlay with deps.dev",

--- a/internal/commands/ecosystems/enrich.go
+++ b/internal/commands/ecosystems/enrich.go
@@ -11,7 +11,7 @@ import (
 	"github.com/snyk/parlay/lib/sbom"
 )
 
-func NewEnrichCommand(logger zerolog.Logger) *cobra.Command {
+func NewEnrichCommand(logger *zerolog.Logger) *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "enrich <sbom>",
 		Short: "Enrich an SBOM with ecosyste.ms data",
@@ -19,7 +19,7 @@ func NewEnrichCommand(logger zerolog.Logger) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			b, err := utils.GetUserInput(args[0], os.Stdin)
 			if err != nil {
-				logger.Fatal().Err(err).Msg("Problem reading input")
+				logger.Fatal().Err(err).Msg("Failed to read input")
 			}
 
 			doc, err := sbom.DecodeSBOMDocument(b)
@@ -27,7 +27,7 @@ func NewEnrichCommand(logger zerolog.Logger) *cobra.Command {
 				logger.Fatal().Err(err).Msg("Failed to read SBOM input")
 			}
 
-			ecosystems.EnrichSBOM(doc)
+			ecosystems.EnrichSBOM(doc, logger)
 
 			if err := doc.Encode(os.Stdout); err != nil {
 				logger.Fatal().Err(err).Msg("Failed to encode new SBOM")

--- a/internal/commands/ecosystems/packages.go
+++ b/internal/commands/ecosystems/packages.go
@@ -10,20 +10,22 @@ import (
 	"github.com/snyk/parlay/lib/ecosystems"
 )
 
-func NewPackageCommand(logger zerolog.Logger) *cobra.Command {
+func NewPackageCommand(logger *zerolog.Logger) *cobra.Command {
 	cmd := cobra.Command{
-		Use:   "package <purl> ",
+		Use:   "package <purl>",
 		Short: "Return package info from ecosyste.ms",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			purl, err := packageurl.FromString(args[0])
 			if err != nil {
-				logger.Fatal().Err(err)
+				logger.Fatal().Err(err).Msg("Failed to parse PackageURL")
 			}
+
 			resp, err := ecosystems.GetPackageData(purl)
 			if err != nil {
-				logger.Fatal().Err(err)
+				logger.Fatal().Err(err).Msg("Failed to get package data from ecosyste.ms")
 			}
+
 			fmt.Print(string(resp.Body))
 		},
 	}

--- a/internal/commands/ecosystems/repos.go
+++ b/internal/commands/ecosystems/repos.go
@@ -9,7 +9,7 @@ import (
 	"github.com/snyk/parlay/lib/ecosystems"
 )
 
-func NewRepoCommand(logger zerolog.Logger) *cobra.Command {
+func NewRepoCommand(logger *zerolog.Logger) *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "repo <host> <repo>",
 		Short: "Return repo info from ecosyste.ms",
@@ -17,7 +17,7 @@ func NewRepoCommand(logger zerolog.Logger) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			resp, err := ecosystems.GetRepoData(args[0])
 			if err != nil {
-				logger.Fatal().Err(err).Msg("An error occurred")
+				logger.Fatal().Err(err).Msg("Failed to get repository data from ecosyste.ms")
 			}
 			fmt.Print(string(resp.Body))
 		},

--- a/internal/commands/ecosystems/root.go
+++ b/internal/commands/ecosystems/root.go
@@ -5,7 +5,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewEcosystemsRootCommand(logger zerolog.Logger) *cobra.Command {
+func NewEcosystemsRootCommand(logger *zerolog.Logger) *cobra.Command {
 	cmd := cobra.Command{
 		Use:                   "ecosystems",
 		Short:                 "Commands for using parlay with ecosystem.ms",

--- a/internal/commands/scorecard/enrich.go
+++ b/internal/commands/scorecard/enrich.go
@@ -11,7 +11,7 @@ import (
 	"github.com/snyk/parlay/lib/scorecard"
 )
 
-func NewEnrichCommand(logger zerolog.Logger) *cobra.Command {
+func NewEnrichCommand(logger *zerolog.Logger) *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "enrich <sbom>",
 		Short: "Enrich an SBOM with OpenSSF Scorecard data",
@@ -19,7 +19,7 @@ func NewEnrichCommand(logger zerolog.Logger) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			b, err := utils.GetUserInput(args[0], os.Stdin)
 			if err != nil {
-				logger.Fatal().Err(err).Msg("Problem reading input")
+				logger.Fatal().Err(err).Msg("Failed to read input")
 			}
 
 			doc, err := sbom.DecodeSBOMDocument(b)

--- a/internal/commands/scorecard/root.go
+++ b/internal/commands/scorecard/root.go
@@ -5,7 +5,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewRootCommand(logger zerolog.Logger) *cobra.Command {
+func NewRootCommand(logger *zerolog.Logger) *cobra.Command {
 	cmd := cobra.Command{
 		Use:                   "scorecard",
 		Short:                 "Commands for using parlay with OpenSSF Scorecard",

--- a/internal/commands/snyk/enrich.go
+++ b/internal/commands/snyk/enrich.go
@@ -11,7 +11,7 @@ import (
 	"github.com/snyk/parlay/lib/snyk"
 )
 
-func NewEnrichCommand(logger zerolog.Logger) *cobra.Command {
+func NewEnrichCommand(logger *zerolog.Logger) *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "enrich <sbom>",
 		Short: "Enrich an SBOM with Snyk data",
@@ -19,7 +19,7 @@ func NewEnrichCommand(logger zerolog.Logger) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			b, err := utils.GetUserInput(args[0], os.Stdin)
 			if err != nil {
-				logger.Fatal().Err(err).Msg("Problem reading input")
+				logger.Fatal().Err(err).Msg("Failed to read input")
 			}
 
 			doc, err := sbom.DecodeSBOMDocument(b)

--- a/internal/commands/snyk/packages.go
+++ b/internal/commands/snyk/packages.go
@@ -10,7 +10,7 @@ import (
 	"github.com/snyk/parlay/lib/snyk"
 )
 
-func NewPackageCommand(logger zerolog.Logger) *cobra.Command {
+func NewPackageCommand(logger *zerolog.Logger) *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "package <purl>",
 		Short: "Return package vulnerabilities from Snyk",
@@ -18,7 +18,7 @@ func NewPackageCommand(logger zerolog.Logger) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			purl, err := packageurl.FromString(args[0])
 			if err != nil {
-				logger.Fatal().Err(err).Msg("Not a valid purl")
+				logger.Fatal().Err(err).Msg("Failed to parse PackageURL")
 			}
 
 			logger.
@@ -31,7 +31,7 @@ func NewPackageCommand(logger zerolog.Logger) *cobra.Command {
 				logger.
 					Fatal().
 					Err(err).
-					Msg("Failed to get API credentials.")
+					Msg("Failed to get API credentials")
 			}
 
 			orgID, err := snyk.SnykOrgID(auth)
@@ -39,12 +39,12 @@ func NewPackageCommand(logger zerolog.Logger) *cobra.Command {
 				logger.
 					Fatal().
 					Err(err).
-					Msg("Failed to look up user info.")
+					Msg("Failed to look up user info")
 			}
 
 			resp, err := snyk.GetPackageVulnerabilities(&purl, auth, orgID)
 			if err != nil {
-				logger.Fatal().Err(err).Msg("An error occurred")
+				logger.Fatal().Err(err).Msg("Failed to look up package vulnerabilities")
 			}
 
 			fmt.Print(string(resp.Body))

--- a/internal/commands/snyk/root.go
+++ b/internal/commands/snyk/root.go
@@ -5,7 +5,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewSnykRootCommand(logger zerolog.Logger) *cobra.Command {
+func NewSnykRootCommand(logger *zerolog.Logger) *cobra.Command {
 	cmd := cobra.Command{
 		Use:                   "snyk",
 		Short:                 "Commands for using parlay with Snyk",
@@ -18,6 +18,7 @@ func NewSnykRootCommand(logger zerolog.Logger) *cobra.Command {
 			}
 		},
 	}
+
 	cmd.AddCommand(NewPackageCommand(logger))
 	cmd.AddCommand(NewEnrichCommand(logger))
 

--- a/lib/ecosystems/enrich.go
+++ b/lib/ecosystems/enrich.go
@@ -18,17 +18,18 @@ package ecosystems
 
 import (
 	cdx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/rs/zerolog"
 	"github.com/spdx/tools-golang/spdx"
 
 	"github.com/snyk/parlay/lib/sbom"
 )
 
-func EnrichSBOM(doc *sbom.SBOMDocument) *sbom.SBOMDocument {
+func EnrichSBOM(doc *sbom.SBOMDocument, logger *zerolog.Logger) *sbom.SBOMDocument {
 	switch bom := doc.BOM.(type) {
 	case *cdx.BOM:
-		enrichCDX(bom)
+		enrichCDX(bom, logger)
 	case *spdx.Document:
-		enrichSPDX(bom)
+		enrichSPDX(bom, logger)
 	}
 	return doc
 }

--- a/lib/ecosystems/enrich_cyclonedx_test.go
+++ b/lib/ecosystems/enrich_cyclonedx_test.go
@@ -23,11 +23,14 @@ import (
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
 	"github.com/jarcoal/httpmock"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/snyk/parlay/ecosystems/packages"
 	"github.com/snyk/parlay/lib/sbom"
 )
+
+var logger = zerolog.Nop()
 
 func TestEnrichSBOM_CycloneDX(t *testing.T) {
 	httpmock.Activate()
@@ -65,7 +68,7 @@ func TestEnrichSBOM_CycloneDX(t *testing.T) {
 	}
 	doc := &sbom.SBOMDocument{BOM: bom}
 
-	EnrichSBOM(doc)
+	EnrichSBOM(doc, &logger)
 
 	components := *bom.Components
 	component := components[0]
@@ -112,7 +115,7 @@ func TestEnrichSBOM_CycloneDX_NestedComps(t *testing.T) {
 	}
 	doc := &sbom.SBOMDocument{BOM: bom}
 
-	EnrichSBOM(doc)
+	EnrichSBOM(doc, &logger)
 
 	httpmock.GetTotalCallCount()
 	calls := httpmock.GetCallCountInfo()
@@ -144,7 +147,7 @@ func TestEnrichSBOMWithoutLicense(t *testing.T) {
 	}
 	doc := &sbom.SBOMDocument{BOM: bom}
 
-	EnrichSBOM(doc)
+	EnrichSBOM(doc, &logger)
 
 	components := *bom.Components
 
@@ -188,7 +191,9 @@ func TestEnrichLicense(t *testing.T) {
 func TestEnrichBlankSBOM(t *testing.T) {
 	bom := new(cdx.BOM)
 	doc := &sbom.SBOMDocument{BOM: bom}
-	EnrichSBOM(doc)
+
+	EnrichSBOM(doc, &logger)
+
 	assert.Nil(t, bom.Components)
 }
 

--- a/lib/ecosystems/enrich_spdx.go
+++ b/lib/ecosystems/enrich_spdx.go
@@ -22,14 +22,17 @@ import (
 	"strings"
 
 	"github.com/package-url/packageurl-go"
+	"github.com/rs/zerolog"
 	"github.com/spdx/tools-golang/spdx"
 	"github.com/spdx/tools-golang/spdx/v2/v2_3"
 
 	"github.com/snyk/parlay/ecosystems/packages"
 )
 
-func enrichSPDX(bom *spdx.Document) {
+func enrichSPDX(bom *spdx.Document, logger *zerolog.Logger) {
 	packages := bom.Packages
+
+	logger.Debug().Msgf("Detected %d packages", len(packages))
 
 	for _, pkg := range packages {
 		purl, err := extractPurl(pkg)

--- a/lib/ecosystems/enrich_spdx_test.go
+++ b/lib/ecosystems/enrich_spdx_test.go
@@ -61,7 +61,7 @@ func TestEnrichSBOM_SPDX(t *testing.T) {
 	}
 	doc := &sbom.SBOMDocument{BOM: bom}
 
-	EnrichSBOM(doc)
+	EnrichSBOM(doc, &logger)
 
 	pkgs := bom.Packages
 

--- a/lib/snyk/enrich.go
+++ b/lib/snyk/enrich.go
@@ -24,7 +24,7 @@ import (
 	"github.com/snyk/parlay/lib/sbom"
 )
 
-func EnrichSBOM(doc *sbom.SBOMDocument, logger zerolog.Logger) *sbom.SBOMDocument {
+func EnrichSBOM(doc *sbom.SBOMDocument, logger *zerolog.Logger) *sbom.SBOMDocument {
 	switch bom := doc.BOM.(type) {
 	case *cdx.BOM:
 		enrichCycloneDX(bom, logger)

--- a/lib/snyk/enrich_test.go
+++ b/lib/snyk/enrich_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/snyk/parlay/lib/sbom"
 )
 
+var logger = zerolog.Nop()
+
 func TestEnrichSBOM_CycloneDXWithVulnerabilities(t *testing.T) {
 	teardown := setupTestEnv(t)
 	defer teardown()
@@ -28,9 +30,8 @@ func TestEnrichSBOM_CycloneDXWithVulnerabilities(t *testing.T) {
 		},
 	}
 	doc := &sbom.SBOMDocument{BOM: bom}
-	logger := zerolog.Nop()
 
-	EnrichSBOM(doc, logger)
+	EnrichSBOM(doc, &logger)
 
 	assert.NotNil(t, bom.Vulnerabilities)
 	assert.Len(t, *bom.Vulnerabilities, 1)
@@ -62,9 +63,8 @@ func TestEnrichSBOM_CycloneDXWithVulnerabilities_NestedComponents(t *testing.T) 
 		},
 	}
 	doc := &sbom.SBOMDocument{BOM: bom}
-	logger := zerolog.Nop()
 
-	EnrichSBOM(doc, logger)
+	EnrichSBOM(doc, &logger)
 
 	assert.NotNil(t, bom.Vulnerabilities)
 	assert.Len(t, *bom.Vulnerabilities, 2)
@@ -85,9 +85,8 @@ func TestEnrichSBOM_CycloneDXWithoutVulnerabilities(t *testing.T) {
 		},
 	}
 	doc := &sbom.SBOMDocument{BOM: bom}
-	logger := zerolog.Nop()
 
-	EnrichSBOM(doc, logger)
+	EnrichSBOM(doc, &logger)
 
 	assert.Nil(t, bom.Vulnerabilities, "should not extend vulnerabilities if there are none")
 }
@@ -113,9 +112,8 @@ func TestEnrichSBOM_SPDXWithVulnerabilities(t *testing.T) {
 		},
 	}
 	doc := &sbom.SBOMDocument{BOM: bom}
-	logger := zerolog.Nop()
 
-	EnrichSBOM(doc, logger)
+	EnrichSBOM(doc, &logger)
 
 	vulnRef := bom.Packages[0].PackageExternalReferences[1]
 	assert.Equal(t, "SECURITY", vulnRef.Category)


### PR DESCRIPTION
This normalizes the style of log messages throughout the different commands, and adds more debug logging, specifically for skipped packages during `enrich` commands (`ecosystems`, `snyk`).

Closes #14.