### PR TITLE
feat: add "/rest" to snyk api url automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ It's important to note vulnerability data is moment-in-time information. By addi
 
 Note the Snyk commands require you to be a Snyk customer, and require passing a valid Snyk API token in the `SNYK_TOKEN` environment variable.
 
-The API base url can be set using the `SNYK_API` environment variable, and if missing it will default to `https://api.snyk.io/rest`.
+The API base url can be set using the `SNYK_API` environment variable, and if missing it will default to `https://api.snyk.io`.
 
 ```
 parlay snyk enrich testing/sbom.cyclonedx.json

--- a/lib/snyk/self.go
+++ b/lib/snyk/self.go
@@ -88,5 +88,5 @@ func APIBaseURL() string {
 	if snykApiEnv != "" {
 		return snykApiEnv
 	}
-	return "https://api.snyk.io/rest"
+	return "https://api.snyk.io"
 }

--- a/snyk/issues/issues.go
+++ b/snyk/issues/issues.go
@@ -548,6 +548,7 @@ func NewClient(server string, opts ...ClientOption) (*Client, error) {
 	if !strings.HasSuffix(client.Server, "/") {
 		client.Server += "/"
 	}
+	client.Server += "rest/"
 	// create httpClient, if not already present
 	if client.Client == nil {
 		client.Client = &http.Client{}

--- a/snyk/users/users.go
+++ b/snyk/users/users.go
@@ -497,6 +497,7 @@ func NewClient(server string, opts ...ClientOption) (*Client, error) {
 	if !strings.HasSuffix(client.Server, "/") {
 		client.Server += "/"
 	}
+	client.Server += "rest/"
 	// create httpClient, if not already present
 	if client.Client == nil {
 		client.Client = &http.Client{}


### PR DESCRIPTION
Currently `parlay` expects users to provide the Snyk API URL with the `/rest` suffix.

This change ensures that the snyk clients add this suffix automatically.