### PR TITLE
fix: empty ecosyste.ms repository url

### DIFF
--- a/lib/scorecard/enrich_cyclonedx.go
+++ b/lib/scorecard/enrich_cyclonedx.go
@@ -62,7 +62,7 @@ func enrichCDX(bom *cdx.BOM) {
 				return
 			}
 
-			if resp.JSON200 == nil || resp.JSON200.RepositoryUrl == nil {
+			if resp.JSON200 == nil || resp.JSON200.RepositoryUrl == nil || *resp.JSON200.RepositoryUrl == "" {
 				return
 			}
 


### PR DESCRIPTION
When doing a `parlay scorecard enrich` if the `repositoryUrl` field returned by `ecosyste.ms` is empty, the code will panic. 

In this change we add an additional check to prevent that behaviour.