### PR TITLE
feat: add supplier to SPDX documents

### DIFF
--- a/lib/ecosystems/enrich_spdx.go
+++ b/lib/ecosystems/enrich_spdx.go
@@ -24,6 +24,7 @@ import (
 	"github.com/package-url/packageurl-go"
 	"github.com/rs/zerolog"
 	"github.com/spdx/tools-golang/spdx"
+	"github.com/spdx/tools-golang/spdx/v2/common"
 	"github.com/spdx/tools-golang/spdx/v2/v2_3"
 
 	"github.com/snyk/parlay/ecosystems/packages"
@@ -53,6 +54,7 @@ func enrichSPDX(bom *spdx.Document, logger *zerolog.Logger) {
 		enrichSPDXDescription(pkg, pkgData)
 		enrichSPDXLicense(pkg, pkgData)
 		enrichSPDXHomepage(pkg, pkgData)
+		enrichSPDXSupplier(pkg, pkgData)
 	}
 }
 
@@ -68,6 +70,20 @@ func extractPurl(pkg *v2_3.Package) (*packageurl.PackageURL, error) {
 		return &purl, nil
 	}
 	return nil, errors.New("no purl found on SPDX package")
+}
+
+func enrichSPDXSupplier(pkg *v2_3.Package, data *packages.Package) {
+	if data.RepoMetadata != nil {
+		meta := *data.RepoMetadata
+		if ownerRecord, ok := meta["owner_record"].(map[string]interface{}); ok {
+			if name, ok := ownerRecord["name"].(string); ok {
+				pkg.PackageSupplier = &common.Supplier{
+					SupplierType: "Organization",
+					Supplier:     name,
+				}
+			}
+		}
+	}
 }
 
 func enrichSPDXLicense(pkg *v2_3.Package, data *packages.Package) {

--- a/lib/ecosystems/enrich_spdx_test.go
+++ b/lib/ecosystems/enrich_spdx_test.go
@@ -41,6 +41,11 @@ func TestEnrichSBOM_SPDX(t *testing.T) {
 					"BSD-3-Clause",
 				},
 				"homepage": "https://github.com/spdx/tools-golang",
+				"repo_metadata": map[string]interface{}{
+					"owner_record": map[string]interface{}{
+						"name": "Acme Corp",
+					},
+				},
 			})
 		})
 
@@ -70,6 +75,8 @@ func TestEnrichSBOM_SPDX(t *testing.T) {
 	assert.Equal(t, "description", pkgs[0].PackageDescription)
 	assert.Equal(t, "BSD-3-Clause", pkgs[0].PackageLicenseConcluded)
 	assert.Equal(t, "https://github.com/spdx/tools-golang", pkgs[0].PackageHomePage)
+	assert.Equal(t, "Organization", pkgs[0].PackageSupplier.SupplierType)
+	assert.Equal(t, "Acme Corp", pkgs[0].PackageSupplier.Supplier)
 
 	httpmock.GetTotalCallCount()
 	calls := httpmock.GetCallCountInfo()


### PR DESCRIPTION
When enriching with ecosyste.ms, add the supplier of a package to an SPDX document.

Closes #76.