### PR TITLE
fix: return ecosyste.ms license based on package version

### DIFF
--- a/internal/utils/spdx.go
+++ b/internal/utils/spdx.go
@@ -2,9 +2,12 @@ package utils
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/package-url/packageurl-go"
 	spdx_2_3 "github.com/spdx/tools-golang/spdx/v2/v2_3"
+
+	"github.com/snyk/parlay/ecosystems/packages"
 )
 
 func GetPurlFromSPDXPackage(pkg *spdx_2_3.Package) (*packageurl.PackageURL, error) {
@@ -27,4 +30,11 @@ func GetPurlFromSPDXPackage(pkg *spdx_2_3.Package) (*packageurl.PackageURL, erro
 	}
 
 	return &purl, nil
+}
+
+func GetSPDXLicenseExpressionFromEcosystemsLicense(data *packages.Version) string {
+	if data == nil || data.Licenses == nil || *data.Licenses == "" {
+		return ""
+	}
+	return fmt.Sprintf("(%s)", strings.Join(strings.Split(*data.Licenses, ","), " OR "))
 }

--- a/internal/utils/spdx_test.go
+++ b/internal/utils/spdx_test.go
@@ -1,0 +1,39 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/snyk/parlay/ecosystems/packages"
+	"github.com/snyk/parlay/internal/utils"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSPDXLicenseExpressionFromEcosystemsLicense(t *testing.T) {
+	assert := assert.New(t)
+	licenses := "GPLv2,MIT"
+	data := packages.Version{Licenses: &licenses}
+	expression := utils.GetSPDXLicenseExpressionFromEcosystemsLicense(&data)
+	assert.Equal("(GPLv2 OR MIT)", expression)
+}
+
+func TestGetSPDXLicenseExpressionFromEcosystemsLicense_NoData(t *testing.T) {
+	assert := assert.New(t)
+	expression := utils.GetSPDXLicenseExpressionFromEcosystemsLicense(nil)
+	assert.Equal("", expression)
+}
+
+func TestGetSPDXLicenseExpressionFromEcosystemsLicense_NoLicenses(t *testing.T) {
+	assert := assert.New(t)
+	data := packages.Version{}
+	expression := utils.GetSPDXLicenseExpressionFromEcosystemsLicense(&data)
+	assert.Equal("", expression)
+}
+
+func TestGetSPDXLicenseExpressionFromEcosystemsLicense_EmptyLicenses(t *testing.T) {
+	assert := assert.New(t)
+	licenses := ""
+	data := packages.Version{Licenses: &licenses}
+	expression := utils.GetSPDXLicenseExpressionFromEcosystemsLicense(&data)
+	assert.Equal("", expression)
+}

--- a/lib/ecosystems/enrich_spdx_test.go
+++ b/lib/ecosystems/enrich_spdx_test.go
@@ -33,11 +33,20 @@ func TestEnrichSBOM_SPDX(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
+	httpmock.RegisterResponder("GET", `=~^https://packages.ecosyste.ms/api/v1/registries/.*/packages/.*/versions`,
+		func(r *http.Request) (*http.Response, error) {
+			return httpmock.NewJsonResponse(200, map[string]interface{}{
+				// This is the license we expect to see for the specific package version
+				"licenses": "MIT",
+			})
+		},
+	)
 	httpmock.RegisterResponder("GET", `=~^https://packages.ecosyste.ms/api/v1/registries`,
 		func(req *http.Request) (*http.Response, error) {
 			return httpmock.NewJsonResponse(200, map[string]interface{}{
 				"description": "description",
 				"normalized_licenses": []string{
+					// This license should be ignored as it corresponds to the latest version of the package
 					"BSD-3-Clause",
 				},
 				"homepage": "https://github.com/spdx/tools-golang",
@@ -73,7 +82,7 @@ func TestEnrichSBOM_SPDX(t *testing.T) {
 	pkgs := bom.Packages
 
 	assert.Equal(t, "description", pkgs[0].PackageDescription)
-	assert.Equal(t, "BSD-3-Clause", pkgs[0].PackageLicenseConcluded)
+	assert.Equal(t, "MIT", pkgs[0].PackageLicenseConcluded)
 	assert.Equal(t, "https://github.com/spdx/tools-golang", pkgs[0].PackageHomePage)
 	assert.Equal(t, "Organization", pkgs[0].PackageSupplier.SupplierType)
 	assert.Equal(t, "Acme Corp", pkgs[0].PackageSupplier.Supplier)

--- a/lib/ecosystems/package.go
+++ b/lib/ecosystems/package.go
@@ -33,13 +33,25 @@ func GetPackageData(purl packageurl.PackageURL) (*packages.GetRegistryPackageRes
 		return nil, err
 	}
 
-	// Ecosyste.ms has a purl based API, but unfortunately slower
-	// so we break the purl down to registry and name values locally
-	// params := packages.LookupPackageParams{Purl: &p}
-	// resp, err := client.LookupPackageWithResponse(context.Background(), &params)
 	name := purlToEcosystemsName(purl)
 	registry := purlToEcosystemsRegistry(purl)
 	resp, err := client.GetRegistryPackageWithResponse(context.Background(), registry, name)
+
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func GetPackageVersionData(purl packageurl.PackageURL) (*packages.GetRegistryPackageVersionResponse, error) {
+	client, err := packages.NewClientWithResponses(server)
+	if err != nil {
+		return nil, err
+	}
+
+	name := purlToEcosystemsName(purl)
+	registry := purlToEcosystemsRegistry(purl)
+	resp, err := client.GetRegistryPackageVersionWithResponse(context.Background(), registry, name, purl.Version)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When enriching with ecosyste.ms, fetch the license based on the package version.

Closes #87 