### PR TITLE
test: replace httpmock

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 go_image: &go_image
   resource_class: small
   docker:
-    - image: cimg/go:1.21
+    - image: cimg/go:1.23
 
 jobs:
   security-scans:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20.3
+        go-version: 1.23.2
 
     - name: Lint
       uses: golangci/golangci-lint-action@v3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snyk/parlay
 
-go 1.20
+go 1.23
 
 require (
 	github.com/CycloneDX/cyclonedx-go v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,7 @@ github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHS
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
+github.com/bradleyjkemp/cupaloy/v2 v2.8.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -73,6 +74,7 @@ github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5y
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
+github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -155,9 +157,11 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
@@ -167,6 +171,7 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/maxatome/go-testdeep v1.12.0 h1:Ql7Go8Tg0C1D/uMMX59LAoYK7LffeJQ6X2T04nTH68g=
+github.com/maxatome/go-testdeep v1.12.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwUBUAfUNvrclaNM=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/package-url/packageurl-go v0.1.2 h1:0H2DQt6DHd/NeRlVwW4EZ4oEI6Bn40XlNPRqegcxuo4=
@@ -182,6 +187,7 @@ github.com/remeh/sizedwaitgroup v1.0.0 h1:VNGGFwNo/R5+MJBf6yrsr110p0m4/OX4S3DCy7
 github.com/remeh/sizedwaitgroup v1.0.0/go.mod h1:3j2R4OIe/SeS6YDhICBy22RWjJC5eNCJ1V+9+NVNYlo=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
+github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.29.1 h1:cO+d60CHkknCbvzEWxP0S9K6KqyTjrCNUy1LdQLCGPc=
 github.com/rs/zerolog v1.29.1/go.mod h1:Le6ESbR7hc+DP6Lt1THiV8CQSdkkNrd3R0XbEgp3ZBU=
@@ -220,9 +226,13 @@ github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8
 github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8=
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/terminalstatic/go-xsd-validate v0.1.5 h1:RqpJnf6HGE2CB/lZB1A8BYguk8uRtcvYAPLCF15qguo=
+github.com/terminalstatic/go-xsd-validate v0.1.5/go.mod h1:18lsvYFofBflqCrvo1umpABZ99+GneNTw2kEEc8UPJw=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/commands/snyk/config.go
+++ b/internal/commands/snyk/config.go
@@ -1,0 +1,20 @@
+package snyk
+
+import (
+	"os"
+
+	"github.com/snyk/parlay/lib/snyk"
+)
+
+func config() *snyk.Config {
+	c := snyk.DefaultConfig()
+
+	if t := os.Getenv("SNYK_TOKEN"); t != "" {
+		c.APIToken = t
+	}
+	if u := os.Getenv("SNYK_API"); u != "" {
+		c.SnykAPIURL = u
+	}
+
+	return c
+}

--- a/internal/commands/snyk/enrich.go
+++ b/internal/commands/snyk/enrich.go
@@ -17,7 +17,8 @@ func NewEnrichCommand(logger *zerolog.Logger) *cobra.Command {
 		Short: "Enrich an SBOM with Snyk data",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			conf := config()
+			cfg := config()
+			svc := snyk.NewService(cfg, logger)
 
 			b, err := utils.GetUserInput(args[0], os.Stdin)
 			if err != nil {
@@ -29,7 +30,7 @@ func NewEnrichCommand(logger *zerolog.Logger) *cobra.Command {
 				logger.Fatal().Err(err).Msg("Failed to read SBOM input")
 			}
 
-			snyk.EnrichSBOM(conf, doc, logger)
+			svc.EnrichSBOM(doc)
 
 			if err := doc.Encode(os.Stdout); err != nil {
 				logger.Fatal().Err(err).Msg("Failed to encode new SBOM")

--- a/internal/commands/snyk/enrich.go
+++ b/internal/commands/snyk/enrich.go
@@ -17,6 +17,8 @@ func NewEnrichCommand(logger *zerolog.Logger) *cobra.Command {
 		Short: "Enrich an SBOM with Snyk data",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			conf := config()
+
 			b, err := utils.GetUserInput(args[0], os.Stdin)
 			if err != nil {
 				logger.Fatal().Err(err).Msg("Failed to read input")
@@ -27,7 +29,7 @@ func NewEnrichCommand(logger *zerolog.Logger) *cobra.Command {
 				logger.Fatal().Err(err).Msg("Failed to read SBOM input")
 			}
 
-			snyk.EnrichSBOM(doc, logger)
+			snyk.EnrichSBOM(conf, doc, logger)
 
 			if err := doc.Encode(os.Stdout); err != nil {
 				logger.Fatal().Err(err).Msg("Failed to encode new SBOM")

--- a/internal/commands/snyk/packages.go
+++ b/internal/commands/snyk/packages.go
@@ -16,7 +16,8 @@ func NewPackageCommand(logger *zerolog.Logger) *cobra.Command {
 		Short: "Return package vulnerabilities from Snyk",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			conf := config()
+			cfg := config()
+			svc := snyk.NewService(cfg, logger)
 
 			purl, err := packageurl.FromString(args[0])
 			if err != nil {
@@ -28,23 +29,7 @@ func NewPackageCommand(logger *zerolog.Logger) *cobra.Command {
 				Str("purl", args[0]).
 				Msg("Looking up package vulnerabilities from Snyk")
 
-			auth, err := snyk.AuthFromToken(conf.APIToken)
-			if err != nil {
-				logger.
-					Fatal().
-					Err(err).
-					Msg("Failed to get API credentials")
-			}
-
-			orgID, err := snyk.SnykOrgID(conf, auth)
-			if err != nil {
-				logger.
-					Fatal().
-					Err(err).
-					Msg("Failed to look up user info")
-			}
-
-			resp, err := snyk.GetPackageVulnerabilities(conf, &purl, auth, orgID)
+			resp, err := svc.GetPackageVulnerabilities(&purl)
 			if err != nil {
 				logger.Fatal().Err(err).Msg("Failed to look up package vulnerabilities")
 			}

--- a/internal/commands/snyk/packages.go
+++ b/internal/commands/snyk/packages.go
@@ -16,6 +16,8 @@ func NewPackageCommand(logger *zerolog.Logger) *cobra.Command {
 		Short: "Return package vulnerabilities from Snyk",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			conf := config()
+
 			purl, err := packageurl.FromString(args[0])
 			if err != nil {
 				logger.Fatal().Err(err).Msg("Failed to parse PackageURL")
@@ -26,7 +28,7 @@ func NewPackageCommand(logger *zerolog.Logger) *cobra.Command {
 				Str("purl", args[0]).
 				Msg("Looking up package vulnerabilities from Snyk")
 
-			auth, err := snyk.AuthFromToken(snyk.APIToken())
+			auth, err := snyk.AuthFromToken(conf.APIToken)
 			if err != nil {
 				logger.
 					Fatal().
@@ -34,7 +36,7 @@ func NewPackageCommand(logger *zerolog.Logger) *cobra.Command {
 					Msg("Failed to get API credentials")
 			}
 
-			orgID, err := snyk.SnykOrgID(auth)
+			orgID, err := snyk.SnykOrgID(conf, auth)
 			if err != nil {
 				logger.
 					Fatal().
@@ -42,7 +44,7 @@ func NewPackageCommand(logger *zerolog.Logger) *cobra.Command {
 					Msg("Failed to look up user info")
 			}
 
-			resp, err := snyk.GetPackageVulnerabilities(&purl, auth, orgID)
+			resp, err := snyk.GetPackageVulnerabilities(conf, &purl, auth, orgID)
 			if err != nil {
 				logger.Fatal().Err(err).Msg("Failed to look up package vulnerabilities")
 			}

--- a/lib/snyk/config.go
+++ b/lib/snyk/config.go
@@ -1,5 +1,5 @@
 /*
- * © 2023 Snyk Limited All rights reserved.
+ * © 2024 Snyk Limited All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,21 +16,17 @@
 
 package snyk
 
-import (
-	cdx "github.com/CycloneDX/cyclonedx-go"
-	"github.com/rs/zerolog"
-	"github.com/spdx/tools-golang/spdx"
+type Config struct {
+	SnykAdvisorWebURL         string
+	SnykVulnerabilityDBWebURL string
+	SnykAPIURL                string
+	APIToken                  string
+}
 
-	"github.com/snyk/parlay/lib/sbom"
-)
-
-func EnrichSBOM(conf *Config, doc *sbom.SBOMDocument, logger *zerolog.Logger) *sbom.SBOMDocument {
-	switch bom := doc.BOM.(type) {
-	case *cdx.BOM:
-		enrichCycloneDX(conf, bom, logger)
-	case *spdx.Document:
-		enrichSPDX(conf, bom, logger)
+func DefaultConfig() *Config {
+	return &Config{
+		SnykAdvisorWebURL:         "https://snyk.io/advisor",
+		SnykVulnerabilityDBWebURL: "https://security.snyk.io",
+		SnykAPIURL:                "https://api.snyk.io",
 	}
-
-	return doc
 }

--- a/lib/snyk/config.go
+++ b/lib/snyk/config.go
@@ -17,16 +17,12 @@
 package snyk
 
 type Config struct {
-	SnykAdvisorWebURL         string
-	SnykVulnerabilityDBWebURL string
-	SnykAPIURL                string
-	APIToken                  string
+	SnykAPIURL string
+	APIToken   string
 }
 
 func DefaultConfig() *Config {
 	return &Config{
-		SnykAdvisorWebURL:         "https://snyk.io/advisor",
-		SnykVulnerabilityDBWebURL: "https://security.snyk.io",
-		SnykAPIURL:                "https://api.snyk.io",
+		SnykAPIURL: "https://api.snyk.io",
 	}
 }

--- a/lib/snyk/enrich.go
+++ b/lib/snyk/enrich.go
@@ -24,12 +24,17 @@ import (
 	"github.com/snyk/parlay/lib/sbom"
 )
 
-func EnrichSBOM(conf *Config, doc *sbom.SBOMDocument, logger *zerolog.Logger) *sbom.SBOMDocument {
+const (
+	snykAdvisorWebURL         = "https://snyk.io/advisor"
+	snykVulnerabilityDBWebURL = "https://security.snyk.io"
+)
+
+func EnrichSBOM(cfg *Config, doc *sbom.SBOMDocument, logger *zerolog.Logger) *sbom.SBOMDocument {
 	switch bom := doc.BOM.(type) {
 	case *cdx.BOM:
-		enrichCycloneDX(conf, bom, logger)
+		enrichCycloneDX(cfg, bom, logger)
 	case *spdx.Document:
-		enrichSPDX(conf, bom, logger)
+		enrichSPDX(cfg, bom, logger)
 	}
 
 	return doc

--- a/lib/snyk/enrich_cyclonedx.go
+++ b/lib/snyk/enrich_cyclonedx.go
@@ -38,8 +38,8 @@ var cdxEnrichers = []cdxEnricher{
 	enrichCDXSnykVulnerabilityDBData,
 }
 
-func enrichCDXSnykVulnerabilityDBData(conf *Config, component *cdx.Component, purl *packageurl.PackageURL) {
-	url := SnykVulnURL(conf, purl)
+func enrichCDXSnykVulnerabilityDBData(cfg *Config, component *cdx.Component, purl *packageurl.PackageURL) {
+	url := SnykVulnURL(cfg, purl)
 	if url != "" {
 		ext := cdx.ExternalReference{
 			URL:     url,
@@ -54,8 +54,8 @@ func enrichCDXSnykVulnerabilityDBData(conf *Config, component *cdx.Component, pu
 	}
 }
 
-func enrichCDXSnykAdvisorData(conf *Config, component *cdx.Component, purl *packageurl.PackageURL) {
-	url := SnykAdvisorURL(conf, purl)
+func enrichCDXSnykAdvisorData(cfg *Config, component *cdx.Component, purl *packageurl.PackageURL) {
+	url := SnykAdvisorURL(cfg, purl)
 	if url != "" {
 		ext := cdx.ExternalReference{
 			URL:     url,
@@ -70,14 +70,14 @@ func enrichCDXSnykAdvisorData(conf *Config, component *cdx.Component, purl *pack
 	}
 }
 
-func enrichCycloneDX(conf *Config, bom *cdx.BOM, logger *zerolog.Logger) *cdx.BOM {
-	auth, err := AuthFromToken(conf.APIToken)
+func enrichCycloneDX(cfg *Config, bom *cdx.BOM, logger *zerolog.Logger) *cdx.BOM {
+	auth, err := AuthFromToken(cfg.APIToken)
 	if err != nil {
 		logger.Fatal().Err(err).Msg("Failed to authenticate")
 		return nil
 	}
 
-	orgID, err := SnykOrgID(conf, auth)
+	orgID, err := SnykOrgID(cfg, auth)
 	if err != nil {
 		logger.Error().Err(err).Msg("Failed to infer preferred Snyk organization")
 		return nil
@@ -105,9 +105,9 @@ func enrichCycloneDX(conf *Config, bom *cdx.BOM, logger *zerolog.Logger) *cdx.BO
 				return
 			}
 			for _, enrichFunc := range cdxEnrichers {
-				enrichFunc(conf, component, &purl)
+				enrichFunc(cfg, component, &purl)
 			}
-			resp, err := GetPackageVulnerabilities(conf, &purl, auth, orgID)
+			resp, err := GetPackageVulnerabilities(cfg, &purl, auth, orgID)
 			if err != nil {
 				l.Err(err).
 					Str("purl", purl.ToString()).
@@ -206,7 +206,7 @@ func enrichCycloneDX(conf *Config, bom *cdx.BOM, logger *zerolog.Logger) *cdx.BO
 					for _, sev := range *issue.Attributes.Severities {
 						source := cdx.Source{
 							Name: "Snyk",
-							URL:  snykVulnDBServer,
+							URL:  snykVulnerabilityDBWebURL,
 						}
 						if sev.Score != nil {
 							score := float64(*sev.Score)

--- a/lib/snyk/enrich_spdx.go
+++ b/lib/snyk/enrich_spdx.go
@@ -39,8 +39,8 @@ var spdxEnrichers = []spdxEnricher{
 	enrichSPDXSnykVulnerabilityDBData,
 }
 
-func enrichSPDXSnykAdvisorData(conf *Config, component *spdx_2_3.Package, purl *packageurl.PackageURL) {
-	url := SnykAdvisorURL(conf, purl)
+func enrichSPDXSnykAdvisorData(cfg *Config, component *spdx_2_3.Package, purl *packageurl.PackageURL) {
+	url := SnykAdvisorURL(cfg, purl)
 	if url != "" {
 		ext := &spdx_2_3.PackageExternalReference{
 			Locator:            url,
@@ -56,8 +56,8 @@ func enrichSPDXSnykAdvisorData(conf *Config, component *spdx_2_3.Package, purl *
 	}
 }
 
-func enrichSPDXSnykVulnerabilityDBData(conf *Config, component *spdx_2_3.Package, purl *packageurl.PackageURL) {
-	url := SnykVulnURL(conf, purl)
+func enrichSPDXSnykVulnerabilityDBData(cfg *Config, component *spdx_2_3.Package, purl *packageurl.PackageURL) {
+	url := SnykVulnURL(cfg, purl)
 	if url != "" {
 		ext := &spdx_2_3.PackageExternalReference{
 			Locator:            url,
@@ -73,8 +73,8 @@ func enrichSPDXSnykVulnerabilityDBData(conf *Config, component *spdx_2_3.Package
 	}
 }
 
-func enrichSPDX(conf *Config, bom *spdx.Document, logger *zerolog.Logger) *spdx.Document {
-	auth, err := AuthFromToken(conf.APIToken)
+func enrichSPDX(cfg *Config, bom *spdx.Document, logger *zerolog.Logger) *spdx.Document {
+	auth, err := AuthFromToken(cfg.APIToken)
 	if err != nil {
 		logger.Fatal().
 			Err(err).
@@ -82,7 +82,7 @@ func enrichSPDX(conf *Config, bom *spdx.Document, logger *zerolog.Logger) *spdx.
 		return nil
 	}
 
-	orgID, err := SnykOrgID(conf, auth)
+	orgID, err := SnykOrgID(cfg, auth)
 	if err != nil {
 		logger.Fatal().
 			Err(err).
@@ -110,9 +110,9 @@ func enrichSPDX(conf *Config, bom *spdx.Document, logger *zerolog.Logger) *spdx.
 				return
 			}
 			for _, enrichFn := range spdxEnrichers {
-				enrichFn(conf, pkg, purl)
+				enrichFn(cfg, pkg, purl)
 			}
-			resp, err := GetPackageVulnerabilities(conf, purl, auth, orgID)
+			resp, err := GetPackageVulnerabilities(cfg, purl, auth, orgID)
 			if err != nil {
 				l.Err(err).
 					Str("purl", purl.ToString()).
@@ -150,7 +150,7 @@ func enrichSPDX(conf *Config, bom *spdx.Document, logger *zerolog.Logger) *spdx.
 				RefType:  spdx.SecurityAdvisory,
 				Locator: fmt.Sprintf(
 					"%s/vuln/%s",
-					conf.SnykVulnerabilityDBWebURL,
+					snykVulnerabilityDBWebURL,
 					url.PathEscape(*issue.Id)),
 			}
 

--- a/lib/snyk/enrich_spdx.go
+++ b/lib/snyk/enrich_spdx.go
@@ -32,19 +32,15 @@ import (
 	"github.com/snyk/parlay/snyk/issues"
 )
 
-const (
-	snykVulnerabilityDB_URI = "https://security.snyk.io"
-)
-
-type spdxEnricher = func(*spdx_2_3.Package, *packageurl.PackageURL)
+type spdxEnricher = func(*Config, *spdx_2_3.Package, *packageurl.PackageURL)
 
 var spdxEnrichers = []spdxEnricher{
 	enrichSPDXSnykAdvisorData,
 	enrichSPDXSnykVulnerabilityDBData,
 }
 
-func enrichSPDXSnykAdvisorData(component *spdx_2_3.Package, purl *packageurl.PackageURL) {
-	url := SnykAdvisorURL(purl)
+func enrichSPDXSnykAdvisorData(conf *Config, component *spdx_2_3.Package, purl *packageurl.PackageURL) {
+	url := SnykAdvisorURL(conf, purl)
 	if url != "" {
 		ext := &spdx_2_3.PackageExternalReference{
 			Locator:            url,
@@ -60,8 +56,8 @@ func enrichSPDXSnykAdvisorData(component *spdx_2_3.Package, purl *packageurl.Pac
 	}
 }
 
-func enrichSPDXSnykVulnerabilityDBData(component *spdx_2_3.Package, purl *packageurl.PackageURL) {
-	url := SnykVulnURL(purl)
+func enrichSPDXSnykVulnerabilityDBData(conf *Config, component *spdx_2_3.Package, purl *packageurl.PackageURL) {
+	url := SnykVulnURL(conf, purl)
 	if url != "" {
 		ext := &spdx_2_3.PackageExternalReference{
 			Locator:            url,
@@ -77,8 +73,8 @@ func enrichSPDXSnykVulnerabilityDBData(component *spdx_2_3.Package, purl *packag
 	}
 }
 
-func enrichSPDX(bom *spdx.Document, logger *zerolog.Logger) *spdx.Document {
-	auth, err := AuthFromToken(APIToken())
+func enrichSPDX(conf *Config, bom *spdx.Document, logger *zerolog.Logger) *spdx.Document {
+	auth, err := AuthFromToken(conf.APIToken)
 	if err != nil {
 		logger.Fatal().
 			Err(err).
@@ -86,7 +82,7 @@ func enrichSPDX(bom *spdx.Document, logger *zerolog.Logger) *spdx.Document {
 		return nil
 	}
 
-	orgID, err := SnykOrgID(auth)
+	orgID, err := SnykOrgID(conf, auth)
 	if err != nil {
 		logger.Fatal().
 			Err(err).
@@ -114,9 +110,9 @@ func enrichSPDX(bom *spdx.Document, logger *zerolog.Logger) *spdx.Document {
 				return
 			}
 			for _, enrichFn := range spdxEnrichers {
-				enrichFn(pkg, purl)
+				enrichFn(conf, pkg, purl)
 			}
-			resp, err := GetPackageVulnerabilities(purl, auth, orgID)
+			resp, err := GetPackageVulnerabilities(conf, purl, auth, orgID)
 			if err != nil {
 				l.Err(err).
 					Str("purl", purl.ToString()).
@@ -154,9 +150,8 @@ func enrichSPDX(bom *spdx.Document, logger *zerolog.Logger) *spdx.Document {
 				RefType:  spdx.SecurityAdvisory,
 				Locator: fmt.Sprintf(
 					"%s/vuln/%s",
-					snykVulnerabilityDB_URI,
-					url.PathEscape(*issue.Id),
-				),
+					conf.SnykVulnerabilityDBWebURL,
+					url.PathEscape(*issue.Id)),
 			}
 
 			if issue.Attributes.Title != nil {

--- a/lib/snyk/enrich_test.go
+++ b/lib/snyk/enrich_test.go
@@ -17,7 +17,10 @@ func TestEnrichSBOM_CycloneDXWithVulnerabilities(t *testing.T) {
 	teardown := setupTestEnv(t)
 	defer teardown()
 
-	conf := newTestConfig(t)
+	cfg := newTestConfig(t)
+	logger := zerolog.Nop()
+	svc := NewService(cfg, &logger)
+
 	bom := &cdx.BOM{
 		Components: &[]cdx.Component{
 			{
@@ -30,8 +33,7 @@ func TestEnrichSBOM_CycloneDXWithVulnerabilities(t *testing.T) {
 	}
 	doc := &sbom.SBOMDocument{BOM: bom}
 
-	logger := zerolog.Nop()
-	EnrichSBOM(conf, doc, &logger)
+	svc.EnrichSBOM(doc)
 
 	assert.NotNil(t, bom.Vulnerabilities)
 	assert.Len(t, *bom.Vulnerabilities, 1)
@@ -44,7 +46,10 @@ func TestEnrichSBOM_CycloneDXExternalRefs(t *testing.T) {
 	teardown := setupTestEnv(t)
 	defer teardown()
 
-	conf := newTestConfig(t)
+	cfg := newTestConfig(t)
+	logger := zerolog.Nop()
+	svc := NewService(cfg, &logger)
+
 	bom := &cdx.BOM{
 		Components: &[]cdx.Component{
 			{
@@ -57,8 +62,7 @@ func TestEnrichSBOM_CycloneDXExternalRefs(t *testing.T) {
 	}
 	doc := &sbom.SBOMDocument{BOM: bom}
 
-	logger := zerolog.Nop()
-	EnrichSBOM(conf, doc, &logger)
+	svc.EnrichSBOM(doc)
 
 	assert.NotNil(t, bom.Components)
 	refs := (*bom.Components)[0].ExternalReferences
@@ -79,7 +83,10 @@ func TestEnrichSBOM_CycloneDXExternalRefs_WithNamespace(t *testing.T) {
 	teardown := setupTestEnv(t)
 	defer teardown()
 
-	conf := newTestConfig(t)
+	cfg := newTestConfig(t)
+	logger := zerolog.Nop()
+	svc := NewService(cfg, &logger)
+
 	bom := &cdx.BOM{
 		Components: &[]cdx.Component{
 			{
@@ -92,8 +99,7 @@ func TestEnrichSBOM_CycloneDXExternalRefs_WithNamespace(t *testing.T) {
 	}
 	doc := &sbom.SBOMDocument{BOM: bom}
 
-	logger := zerolog.Nop()
-	EnrichSBOM(conf, doc, &logger)
+	svc.EnrichSBOM(doc)
 
 	assert.NotNil(t, bom.Components)
 	refs := (*bom.Components)[0].ExternalReferences
@@ -114,7 +120,10 @@ func TestEnrichSBOM_CycloneDXWithVulnerabilities_NestedComponents(t *testing.T) 
 	teardown := setupTestEnv(t)
 	defer teardown()
 
-	conf := newTestConfig(t)
+	cfg := newTestConfig(t)
+	logger := zerolog.Nop()
+	svc := NewService(cfg, &logger)
+
 	bom := &cdx.BOM{
 		Components: &[]cdx.Component{
 			{
@@ -135,8 +144,7 @@ func TestEnrichSBOM_CycloneDXWithVulnerabilities_NestedComponents(t *testing.T) 
 	}
 	doc := &sbom.SBOMDocument{BOM: bom}
 
-	logger := zerolog.Nop()
-	EnrichSBOM(conf, doc, &logger)
+	svc.EnrichSBOM(doc)
 
 	assert.NotNil(t, bom.Vulnerabilities)
 	assert.Len(t, *bom.Vulnerabilities, 2)
@@ -146,7 +154,10 @@ func TestEnrichSBOM_CycloneDXWithoutVulnerabilities(t *testing.T) {
 	teardown := setupTestEnv(t)
 	defer teardown()
 
-	conf := newTestConfig(t)
+	cfg := newTestConfig(t)
+	logger := zerolog.Nop()
+	svc := NewService(cfg, &logger)
+
 	bom := &cdx.BOM{
 		Components: &[]cdx.Component{
 			{
@@ -159,8 +170,7 @@ func TestEnrichSBOM_CycloneDXWithoutVulnerabilities(t *testing.T) {
 	}
 	doc := &sbom.SBOMDocument{BOM: bom}
 
-	logger := zerolog.Nop()
-	EnrichSBOM(conf, doc, &logger)
+	svc.EnrichSBOM(doc)
 
 	assert.Nil(t, bom.Vulnerabilities, "should not extend vulnerabilities if there are none")
 }
@@ -169,7 +179,10 @@ func TestEnrichSBOM_SPDXWithVulnerabilities(t *testing.T) {
 	teardown := setupTestEnv(t)
 	defer teardown()
 
-	conf := newTestConfig(t)
+	cfg := newTestConfig(t)
+	logger := zerolog.Nop()
+	svc := NewService(cfg, &logger)
+
 	bom := &spdx_2_3.Document{
 		Packages: []*spdx_2_3.Package{
 			{
@@ -188,8 +201,7 @@ func TestEnrichSBOM_SPDXWithVulnerabilities(t *testing.T) {
 	}
 	doc := &sbom.SBOMDocument{BOM: bom}
 
-	logger := zerolog.Nop()
-	EnrichSBOM(conf, doc, &logger)
+	svc.EnrichSBOM(doc)
 
 	vulnRef := bom.Packages[0].PackageExternalReferences[3]
 	assert.Equal(t, "SECURITY", vulnRef.Category)
@@ -202,7 +214,10 @@ func TestEnrichSBOM_SPDXExternalRefs(t *testing.T) {
 	teardown := setupTestEnv(t)
 	defer teardown()
 
-	conf := newTestConfig(t)
+	cfg := newTestConfig(t)
+	logger := zerolog.Nop()
+	svc := NewService(cfg, &logger)
+
 	bom := &spdx_2_3.Document{
 		Packages: []*spdx_2_3.Package{
 			{
@@ -222,8 +237,7 @@ func TestEnrichSBOM_SPDXExternalRefs(t *testing.T) {
 
 	doc := &sbom.SBOMDocument{BOM: bom}
 
-	logger := zerolog.Nop()
-	EnrichSBOM(conf, doc, &logger)
+	svc.EnrichSBOM(doc)
 
 	assert.NotNil(t, bom.Packages)
 	refs := (*bom.Packages[0]).PackageExternalReferences

--- a/lib/snyk/package.go
+++ b/lib/snyk/package.go
@@ -31,7 +31,7 @@ import (
 const (
 	version           = "2023-04-28"
 	snykAdvisorServer = "https://snyk.io/advisor"
-	snykVulnDBServer  = "https://security.snyk.io/package"
+	snykVulnDBServer  = "https://security.snyk.io"
 )
 
 func purlToSnykAdvisor(purl *packageurl.PackageURL) string {
@@ -43,12 +43,12 @@ func purlToSnykAdvisor(purl *packageurl.PackageURL) string {
 	}[purl.Type]
 }
 
-func SnykAdvisorURL(purl *packageurl.PackageURL) string {
+func SnykAdvisorURL(conf *Config, purl *packageurl.PackageURL) string {
 	ecosystem := purlToSnykAdvisor(purl)
 	if ecosystem == "" {
 		return ""
 	}
-	url := snykAdvisorServer + "/" + ecosystem + "/"
+	url := conf.SnykAdvisorWebURL + "/" + ecosystem + "/"
 	if purl.Namespace != "" {
 		url += purl.Namespace + "/"
 	}
@@ -73,12 +73,12 @@ func purlToSnykVulnDB(purl *packageurl.PackageURL) string {
 	}[purl.Type]
 }
 
-func SnykVulnURL(purl *packageurl.PackageURL) string {
+func SnykVulnURL(conf *Config, purl *packageurl.PackageURL) string {
 	ecosystem := purlToSnykVulnDB(purl)
 	if ecosystem == "" {
 		return ""
 	}
-	url := snykVulnDBServer + "/" + ecosystem + "/"
+	url := conf.SnykVulnerabilityDBWebURL + "/package/" + ecosystem + "/"
 	if purl.Namespace != "" {
 		url += purl.Namespace + "%2F"
 	}
@@ -86,8 +86,8 @@ func SnykVulnURL(purl *packageurl.PackageURL) string {
 	return url
 }
 
-func GetPackageVulnerabilities(purl *packageurl.PackageURL, auth *securityprovider.SecurityProviderApiKey, orgID *uuid.UUID) (*issues.FetchIssuesPerPurlResponse, error) {
-	client, err := issues.NewClientWithResponses(APIBaseURL(), issues.WithRequestEditorFn(auth.Intercept))
+func GetPackageVulnerabilities(conf *Config, purl *packageurl.PackageURL, auth *securityprovider.SecurityProviderApiKey, orgID *uuid.UUID) (*issues.FetchIssuesPerPurlResponse, error) {
+	client, err := issues.NewClientWithResponses(conf.SnykAPIURL, issues.WithRequestEditorFn(auth.Intercept))
 	if err != nil {
 		return nil, err
 	}

--- a/lib/snyk/package.go
+++ b/lib/snyk/package.go
@@ -28,11 +28,7 @@ import (
 	"github.com/snyk/parlay/snyk/issues"
 )
 
-const (
-	version           = "2023-04-28"
-	snykAdvisorServer = "https://snyk.io/advisor"
-	snykVulnDBServer  = "https://security.snyk.io"
-)
+const version = "2023-04-28"
 
 func purlToSnykAdvisor(purl *packageurl.PackageURL) string {
 	return map[string]string{
@@ -43,12 +39,12 @@ func purlToSnykAdvisor(purl *packageurl.PackageURL) string {
 	}[purl.Type]
 }
 
-func SnykAdvisorURL(conf *Config, purl *packageurl.PackageURL) string {
+func SnykAdvisorURL(cfg *Config, purl *packageurl.PackageURL) string {
 	ecosystem := purlToSnykAdvisor(purl)
 	if ecosystem == "" {
 		return ""
 	}
-	url := conf.SnykAdvisorWebURL + "/" + ecosystem + "/"
+	url := snykAdvisorWebURL + "/" + ecosystem + "/"
 	if purl.Namespace != "" {
 		url += purl.Namespace + "/"
 	}
@@ -73,12 +69,12 @@ func purlToSnykVulnDB(purl *packageurl.PackageURL) string {
 	}[purl.Type]
 }
 
-func SnykVulnURL(conf *Config, purl *packageurl.PackageURL) string {
+func SnykVulnURL(cfg *Config, purl *packageurl.PackageURL) string {
 	ecosystem := purlToSnykVulnDB(purl)
 	if ecosystem == "" {
 		return ""
 	}
-	url := conf.SnykVulnerabilityDBWebURL + "/package/" + ecosystem + "/"
+	url := snykVulnerabilityDBWebURL + "/package/" + ecosystem + "/"
 	if purl.Namespace != "" {
 		url += purl.Namespace + "%2F"
 	}
@@ -86,8 +82,8 @@ func SnykVulnURL(conf *Config, purl *packageurl.PackageURL) string {
 	return url
 }
 
-func GetPackageVulnerabilities(conf *Config, purl *packageurl.PackageURL, auth *securityprovider.SecurityProviderApiKey, orgID *uuid.UUID) (*issues.FetchIssuesPerPurlResponse, error) {
-	client, err := issues.NewClientWithResponses(conf.SnykAPIURL, issues.WithRequestEditorFn(auth.Intercept))
+func GetPackageVulnerabilities(cfg *Config, purl *packageurl.PackageURL, auth *securityprovider.SecurityProviderApiKey, orgID *uuid.UUID) (*issues.FetchIssuesPerPurlResponse, error) {
+	client, err := issues.NewClientWithResponses(cfg.SnykAPIURL, issues.WithRequestEditorFn(auth.Intercept))
 	if err != nil {
 		return nil, err
 	}

--- a/lib/snyk/self.go
+++ b/lib/snyk/self.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 
 	"github.com/deepmap/oapi-codegen/pkg/securityprovider"
 	"github.com/google/uuid"
@@ -38,8 +37,8 @@ type selfDocument struct {
 	}
 }
 
-func SnykOrgID(auth *securityprovider.SecurityProviderApiKey) (*uuid.UUID, error) {
-	experimental, err := users.NewClientWithResponses(APIBaseURL(), users.WithRequestEditorFn(auth.Intercept))
+func SnykOrgID(conf *Config, auth *securityprovider.SecurityProviderApiKey) (*uuid.UUID, error) {
+	experimental, err := users.NewClientWithResponses(conf.SnykAPIURL, users.WithRequestEditorFn(auth.Intercept))
 	if err != nil {
 		return nil, err
 	}
@@ -77,16 +76,4 @@ func AuthFromToken(token string) (*securityprovider.SecurityProviderApiKey, erro
 	}
 
 	return auth, nil
-}
-
-func APIToken() string {
-	return os.Getenv("SNYK_TOKEN")
-}
-
-func APIBaseURL() string {
-	snykApiEnv := os.Getenv("SNYK_API")
-	if snykApiEnv != "" {
-		return snykApiEnv
-	}
-	return "https://api.snyk.io"
 }

--- a/lib/snyk/self.go
+++ b/lib/snyk/self.go
@@ -37,8 +37,8 @@ type selfDocument struct {
 	}
 }
 
-func SnykOrgID(conf *Config, auth *securityprovider.SecurityProviderApiKey) (*uuid.UUID, error) {
-	experimental, err := users.NewClientWithResponses(conf.SnykAPIURL, users.WithRequestEditorFn(auth.Intercept))
+func SnykOrgID(cfg *Config, auth *securityprovider.SecurityProviderApiKey) (*uuid.UUID, error) {
+	experimental, err := users.NewClientWithResponses(cfg.SnykAPIURL, users.WithRequestEditorFn(auth.Intercept))
 	if err != nil {
 		return nil, err
 	}

--- a/lib/snyk/self_test.go
+++ b/lib/snyk/self_test.go
@@ -38,7 +38,7 @@ func TestGetSnykOrg_Success(t *testing.T) {
 		httpmock.NewJsonResponderOrPanic(http.StatusOK, httpmock.File("testdata/self.json")),
 	)
 
-	actualOrg, err := SnykOrgID(auth)
+	actualOrg, err := SnykOrgID(DefaultConfig(), auth)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedOrg, *actualOrg)
 }
@@ -53,7 +53,7 @@ func TestGetSnykOrg_Unauthorized(t *testing.T) {
 		httpmock.NewJsonResponderOrPanic(http.StatusUnauthorized, []byte(`{"msg":"unauthorized"}`)),
 	)
 
-	actualOrg, err := SnykOrgID(auth)
+	actualOrg, err := SnykOrgID(DefaultConfig(), auth)
 	assert.ErrorContains(t, err, "Failed to get user info (401)")
 	assert.Nil(t, actualOrg)
 }

--- a/lib/snyk/self_test.go
+++ b/lib/snyk/self_test.go
@@ -17,43 +17,51 @@
 package snyk
 
 import (
+	_ "embed"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/deepmap/oapi-codegen/pkg/securityprovider"
 	"github.com/google/uuid"
-	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+//go:embed testdata/self.json
+var selfBody []byte
+
 func TestSnykOrgID_Success(t *testing.T) {
-	expectedOrg := uuid.MustParse("00000000-0000-0000-0000-000000000000")
-	auth, err := securityprovider.NewSecurityProviderApiKey("header", "name", "value")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		respond(w, selfBody)
+	}))
+	defer srv.Close()
+
+	cfg := DefaultConfig()
+	cfg.SnykAPIURL = srv.URL
+	auth, err := securityprovider.NewSecurityProviderApiKey("header", "authorization", "asdf")
 	require.NoError(t, err)
 
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
-	httpmock.RegisterResponder("GET", "https://api.snyk.io/rest/self",
-		httpmock.NewJsonResponderOrPanic(http.StatusOK, httpmock.File("testdata/self.json")),
-	)
+	actualOrg, err := SnykOrgID(cfg, auth)
 
-	actualOrg, err := SnykOrgID(DefaultConfig(), auth)
 	assert.NoError(t, err)
-	assert.Equal(t, expectedOrg, *actualOrg)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000000"), *actualOrg)
 }
 
 func TestSnykOrgID_Unauthorized(t *testing.T) {
-	auth, err := securityprovider.NewSecurityProviderApiKey("header", "name", "value")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		respond(w, []byte(`{"msg":"unauthorized"}`))
+	}))
+	defer srv.Close()
+
+	cfg := DefaultConfig()
+	cfg.SnykAPIURL = srv.URL
+	auth, err := securityprovider.NewSecurityProviderApiKey("header", "authorization", "asdf")
 	require.NoError(t, err)
 
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
-	httpmock.RegisterResponder("GET", "https://api.snyk.io/rest/self",
-		httpmock.NewJsonResponderOrPanic(http.StatusUnauthorized, []byte(`{"msg":"unauthorized"}`)),
-	)
+	actualOrg, err := SnykOrgID(cfg, auth)
 
-	actualOrg, err := SnykOrgID(DefaultConfig(), auth)
-	assert.ErrorContains(t, err, "Failed to get user info (401)")
+	assert.ErrorContains(t, err, "Failed to get user info (401 Unauthorized)")
 	assert.Nil(t, actualOrg)
 }

--- a/lib/snyk/self_test.go
+++ b/lib/snyk/self_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetSnykOrg_Success(t *testing.T) {
+func TestSnykOrgID_Success(t *testing.T) {
 	expectedOrg := uuid.MustParse("00000000-0000-0000-0000-000000000000")
 	auth, err := securityprovider.NewSecurityProviderApiKey("header", "name", "value")
 	require.NoError(t, err)
@@ -43,7 +43,7 @@ func TestGetSnykOrg_Success(t *testing.T) {
 	assert.Equal(t, expectedOrg, *actualOrg)
 }
 
-func TestGetSnykOrg_Unauthorized(t *testing.T) {
+func TestSnykOrgID_Unauthorized(t *testing.T) {
 	auth, err := securityprovider.NewSecurityProviderApiKey("header", "name", "value")
 	require.NoError(t, err)
 

--- a/lib/snyk/service.go
+++ b/lib/snyk/service.go
@@ -1,0 +1,53 @@
+package snyk
+
+import (
+	"github.com/deepmap/oapi-codegen/pkg/securityprovider"
+	"github.com/google/uuid"
+	"github.com/package-url/packageurl-go"
+	"github.com/rs/zerolog"
+
+	"github.com/snyk/parlay/lib/sbom"
+	"github.com/snyk/parlay/snyk/issues"
+)
+
+type Service interface {
+	EnrichSBOM(*sbom.SBOMDocument) *sbom.SBOMDocument
+	GetPackageVulnerabilities(*packageurl.PackageURL) (*issues.FetchIssuesPerPurlResponse, error)
+}
+
+type serviceImpl struct {
+	cfg    *Config
+	logger *zerolog.Logger
+}
+
+var _ Service = (*serviceImpl)(nil)
+
+func NewService(cfg *Config, logger *zerolog.Logger) Service {
+	return &serviceImpl{cfg, logger}
+}
+
+func (svc *serviceImpl) EnrichSBOM(doc *sbom.SBOMDocument) *sbom.SBOMDocument {
+	return EnrichSBOM(svc.cfg, doc, svc.logger)
+}
+
+func (svc *serviceImpl) GetPackageVulnerabilities(purl *packageurl.PackageURL) (*issues.FetchIssuesPerPurlResponse, error) {
+	auth, err := svc.getAuth()
+	if err != nil {
+		return nil, err
+	}
+
+	orgID, err := svc.getOrgID(auth)
+	if err != nil {
+		return nil, err
+	}
+
+	return GetPackageVulnerabilities(svc.cfg, purl, auth, orgID)
+}
+
+func (svc *serviceImpl) getAuth() (*securityprovider.SecurityProviderApiKey, error) {
+	return AuthFromToken(svc.cfg.APIToken)
+}
+
+func (svc *serviceImpl) getOrgID(auth *securityprovider.SecurityProviderApiKey) (*uuid.UUID, error) {
+	return SnykOrgID(svc.cfg, auth)
+}


### PR DESCRIPTION
Replacing the dependency on `httpmock` with `httptest`. Making a start with the `snyk` command.