### PR TITLE
fix: backoff function error handling

### DIFF
--- a/lib/snyk/package_test.go
+++ b/lib/snyk/package_test.go
@@ -58,3 +58,34 @@ func TestGetPackageVulnerabilities_RetryRateLimited(t *testing.T) {
 	assert.Equal(t, 2, numRequests, "retries failed requests")
 	assert.NotNil(t, issues, "should retrieve issues")
 }
+
+func TestGetPackageVulnerabilities_HandlesNilResponses(t *testing.T) {
+	logger := zerolog.Nop()
+	var numRequests int
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		numRequests++
+		if numRequests < 5 {
+			w.Header().Set("X-RateLimit-Reset", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		// Induce a client error which results in a nil response
+		srv.CloseClientConnections()
+	}))
+
+	cfg := DefaultConfig()
+	cfg.SnykAPIURL = srv.URL
+
+	auth, err := AuthFromToken("asdf")
+	require.NoError(t, err)
+
+	purl, err := packageurl.FromString("pkg:golang/github.com/snyk/parlay")
+	require.NoError(t, err)
+
+	orgID := uuid.New()
+	issues, err := GetPackageVulnerabilities(cfg, &purl, auth, &orgID, &logger)
+
+	require.Error(t, err)
+	assert.Nil(t, issues)
+}


### PR DESCRIPTION
When calling the `Backoff` function of the `retryablehttp` client, the responses will be `nil` if an error occurs. This PR addresses this issue and also adds the `PassthroughErrorHandler` to the client in order to propagate more error details.