### PR TITLE
Correct cvss version

### DIFF
--- a/lib/snyk/enrich_cyclonedx.go
+++ b/lib/snyk/enrich_cyclonedx.go
@@ -225,7 +225,7 @@ func enrichCycloneDX(cfg *Config, bom *cdx.BOM, logger *zerolog.Logger) *cdx.BOM
 								Source:   &source,
 								Score:    &score,
 								Severity: levelToCdxSeverity(sev.Level),
-								Method:   "CVSSv31",
+								Method:   versionToCdxMethod(sev.Version),
 								Vector:   *sev.Vector,
 							}
 							if vuln.Ratings == nil {
@@ -263,6 +263,20 @@ func levelToCdxSeverity(level *string) (severity cdx.Severity) {
 		severity = cdx.SeverityLow
 	default:
 		severity = cdx.SeverityUnknown
+	}
+	return
+}
+
+func versionToCdxMethod(version *string) (method cdx.ScoringMethod) {
+	switch *version {
+	case "3.0":
+		method = cdx.ScoringMethodCVSSv3
+	case "3.1":
+		method = cdx.ScoringMethodCVSSv31
+	case "4.0":
+		method = cdx.ScoringMethodCVSSv4
+	default:
+		method = cdx.ScoringMethodOther
 	}
 	return
 }

--- a/lib/snyk/enrich_test.go
+++ b/lib/snyk/enrich_test.go
@@ -51,7 +51,9 @@ func TestEnrichSBOM_CycloneDXWithVulnerabilities(t *testing.T) {
 	assert.NotNil(t, vuln.Ratings)
 	assert.Len(t, *vuln.Ratings, 4)
 	assert.Equal(t, (*vuln.Ratings)[0].Source, &cdx.Source{Name: "Snyk", URL: "https://security.snyk.io"})
+	assert.Equal(t, (*vuln.Ratings)[0].Method, cdx.ScoringMethodCVSSv31)
 	assert.Equal(t, (*vuln.Ratings)[1].Source, &cdx.Source{Name: "NVD"})
+	assert.Equal(t, (*vuln.Ratings)[1].Method, cdx.ScoringMethodCVSSv3)
 }
 
 func TestEnrichSBOM_CycloneDXExternalRefs(t *testing.T) {

--- a/lib/snyk/package.go
+++ b/lib/snyk/package.go
@@ -32,7 +32,7 @@ import (
 	"github.com/snyk/parlay/snyk/issues"
 )
 
-const version = "2023-04-28"
+const version = "2024-06-26"
 
 func purlToSnykAdvisor(purl *packageurl.PackageURL) string {
 	return map[string]string{


### PR DESCRIPTION
This change updates the Snyk API to the latest version for package information, which contains CVSSv4 information for some vulnerabilities. Note this change also fixes a big were the CVSS version was hardcoded to 3.1, and could have been either 3.0 and 3.1.

@mcombuechen this builds on top of your update to build the clients with the up to date specs, which suggests it works. If you land that, I can rebase that out of here if you like.