### PR TITLE
Add OSV support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snyk/parlay
 
-go 1.23
+go 1.24.1
 
 require (
 	github.com/CycloneDX/cyclonedx-go v0.9.2
@@ -9,8 +9,9 @@ require (
 	github.com/google/uuid v1.5.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/jarcoal/httpmock v1.3.0
+	github.com/jvpascal/osvwrapper v0.0.0-20250516001142-6aad5e1eb362
 	github.com/oapi-codegen/runtime v1.1.1
-	github.com/package-url/packageurl-go v0.1.2
+	github.com/package-url/packageurl-go v0.1.3
 	github.com/remeh/sizedwaitgroup v1.0.0
 	github.com/rs/zerolog v1.29.1
 	github.com/spdx/tools-golang v0.5.4-0.20240304222056-8baafa1a79c4
@@ -39,6 +40,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
+	github.com/synk-labs/parlay v0.0.0-20250515234845-43e4661b65f3 // indirect
 	golang.org/x/sys v0.20.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -161,6 +161,8 @@ github.com/jarcoal/httpmock v1.3.0/go.mod h1:3yb8rc4BI7TCBhFY8ng0gjuLKJNquuDNiPa
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
+github.com/jvpascal/osvwrapper v0.0.0-20250516001142-6aad5e1eb362 h1:qsa1Kw2BCE2RL/6u8uooNkAoZxY0MQun5e5YGOIHm3k=
+github.com/jvpascal/osvwrapper v0.0.0-20250516001142-6aad5e1eb362/go.mod h1:6ZNMOnIJ5f1Nul+HUmM9XyzY+iTepLyMq/NmJ6F3WXE=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -185,8 +187,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/oapi-codegen/runtime v1.1.1 h1:EXLHh0DXIJnWhdRPN2w4MXAzFyE4CskzhNLUmtpMYro=
 github.com/oapi-codegen/runtime v1.1.1/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
-github.com/package-url/packageurl-go v0.1.2 h1:0H2DQt6DHd/NeRlVwW4EZ4oEI6Bn40XlNPRqegcxuo4=
-github.com/package-url/packageurl-go v0.1.2/go.mod h1:uQd4a7Rh3ZsVg5j0lNyAfyxIeGde9yrlhjF78GzeW0c=
+github.com/package-url/packageurl-go v0.1.3 h1:4juMED3hHiz0set3Vq3KeQ75KD1avthoXLtmE3I0PLs=
+github.com/package-url/packageurl-go v0.1.3/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
 github.com/pelletier/go-toml/v2 v2.0.9 h1:uH2qQXheeefCCkuBBSLi7jCiSmj3VRh2+Goq2N7Xxu0=
 github.com/pelletier/go-toml/v2 v2.0.9/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -236,6 +238,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8=
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
+github.com/synk-labs/parlay v0.0.0-20250515234845-43e4661b65f3 h1:vxTmw+dyPkX5dZA4fRuQCXTCt0MO91lJdJvRcu2d9mE=
+github.com/synk-labs/parlay v0.0.0-20250515234845-43e4661b65f3/go.mod h1:ea37arBPUCoMDWm05rbZSMXMDhuRIUDjCwT0u4gHHFU=
 github.com/terminalstatic/go-xsd-validate v0.1.6 h1:TenYeQ3eY631qNi1/cTmLH/s2slHPRKTTHT+XSHkepo=
 github.com/terminalstatic/go-xsd-validate v0.1.6/go.mod h1:18lsvYFofBflqCrvo1umpABZ99+GneNTw2kEEc8UPJw=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=

--- a/internal/commands/default.go
+++ b/internal/commands/default.go
@@ -11,6 +11,7 @@ import (
 	"github.com/snyk/parlay/internal/commands/ecosystems"
 	"github.com/snyk/parlay/internal/commands/scorecard"
 	"github.com/snyk/parlay/internal/commands/snyk"
+	"github.com/snyk/parlay/internal/commands/osv"
 )
 
 // These values are set at build time
@@ -52,6 +53,7 @@ func NewDefaultCommand() *cobra.Command {
 	cmd.AddCommand(snyk.NewSnykRootCommand(&logger))
 	cmd.AddCommand(deps.NewDepsRootCommand(&logger))
 	cmd.AddCommand(scorecard.NewRootCommand(&logger))
+	cmd.AddCommand(osv.NewRootCommand(&logger))
 
 	return &cmd
 }

--- a/internal/commands/osv/enrich.go
+++ b/internal/commands/osv/enrich.go
@@ -1,0 +1,38 @@
+package osv
+
+import (
+	"os"
+
+	"github.com/rs/zerolog"
+	"github.com/spf13/cobra"
+
+	"github.com/snyk/parlay/internal/utils"
+	"github.com/snyk/parlay/lib/sbom"
+	"github.com/snyk/parlay/lib/osv"
+)
+
+func NewEnrichCommand(logger *zerolog.Logger) *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "enrich <sbom>",
+		Short: "Enrich an SBOM with OSV data",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			b, err := utils.GetUserInput(args[0], os.Stdin)
+			if err != nil {
+				logger.Fatal().Err(err).Msg("Failed to read input")
+			}
+
+			doc, err := sbom.DecodeSBOMDocument(b)
+			if err != nil {
+				logger.Fatal().Err(err).Msg("Failed to read SBOM input")
+			}
+
+			osv.EnrichSBOM(doc)
+
+			if err := doc.Encode(os.Stdout); err != nil {
+				logger.Fatal().Err(err).Msg("Failed to encode new SBOM")
+			}
+		},
+	}
+	return &cmd
+}

--- a/internal/commands/osv/root.go
+++ b/internal/commands/osv/root.go
@@ -1,0 +1,25 @@
+package osv
+
+import (
+	"github.com/rs/zerolog"
+	"github.com/spf13/cobra"
+)
+
+func NewRootCommand(logger *zerolog.Logger) *cobra.Command {
+	cmd := cobra.Command{
+		Use:                   "osv",
+		Short:                 "Commands for using parlay with Open Source Vulnerability database content",
+		Aliases:               []string{"s"},
+		DisableFlagsInUseLine: true,
+		SilenceUsage:          true,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := cmd.Help(); err != nil {
+				logger.Fatal().Err(err).Msg("Failed to run osv command")
+			}
+		},
+	}
+
+	cmd.AddCommand(NewEnrichCommand(logger))
+
+	return &cmd
+}

--- a/lib/osv/enrich.go
+++ b/lib/osv/enrich.go
@@ -1,0 +1,35 @@
+/*
+ * © 2025 Snyk Limited All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package osv
+
+import (
+	cdx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/spdx/tools-golang/spdx"
+
+	"github.com/snyk/parlay/lib/sbom"
+)
+
+func EnrichSBOM(doc *sbom.SBOMDocument) *sbom.SBOMDocument {
+	switch bom := doc.BOM.(type) {
+	case *cdx.BOM:
+		enrichCDX(bom)
+	case *spdx.Document:
+		enrichSPDX(bom)
+	}
+
+	return doc
+}

--- a/lib/osv/enrich_cyclonedx.go
+++ b/lib/osv/enrich_cyclonedx.go
@@ -1,0 +1,61 @@
+/*
+ * © 2023 Snyk Limited All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package osv
+
+import (
+	cdx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/remeh/sizedwaitgroup"
+
+	"github.com/snyk/parlay/internal/utils"
+	"github.com/jvpascal/osvwrapper"
+)
+
+func cdxEnrichExternalReference(comp *cdx.Component, url, comment string, refType cdx.ExternalReferenceType) {
+	ext := cdx.ExternalReference{
+		URL:     url,
+		Comment: comment,
+		Type:    refType,
+	}
+
+	if comp.ExternalReferences == nil {
+		comp.ExternalReferences = &[]cdx.ExternalReference{ext}
+	} else {
+		*comp.ExternalReferences = append(*comp.ExternalReferences, ext)
+	}
+}
+
+func enrichCDX(bom *cdx.BOM) {
+	comps := utils.DiscoverCDXComponents(bom)
+
+	wg := sizedwaitgroup.New(20)
+
+	for i := range comps {
+		wg.Add()
+		go func(component *cdx.Component) {
+			defer wg.Done()
+
+			vuln_report, err := osvwrapper.OSVQuery(component.PackageURL)
+			if err != nil {
+				return
+			}
+
+			cdxEnrichExternalReference(component, "https://api.osv.dev/v1/query", vuln_report, cdx.ERTypeVulnerabilityAssertion)
+		}(comps[i])
+	}
+
+	wg.Wait()
+}

--- a/lib/osv/enrich_spdx.go
+++ b/lib/osv/enrich_spdx.go
@@ -1,0 +1,57 @@
+/*
+ * © 2025 Snyk Limited All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package osv
+
+import (
+	"github.com/remeh/sizedwaitgroup"
+	"github.com/spdx/tools-golang/spdx"
+	spdx_2_3 "github.com/spdx/tools-golang/spdx/v2/v2_3"
+
+	"github.com/snyk/parlay/internal/utils"
+	"github.com/jvpascal/osvwrapper"
+)
+
+func enrichSPDX(bom *spdx.Document) {
+	wg := sizedwaitgroup.New(20)
+
+	for i, pkg := range bom.Packages {
+		wg.Add()
+
+		go func(pkg *spdx_2_3.Package, i int) {
+			defer wg.Done()
+
+			purl, err := utils.GetPurlFromSPDXPackage(pkg)
+			if err != nil {
+				return
+			}
+
+			vuln_report, err := osvwrapper.OSVQuery(purl.ToString())
+			if err != nil {
+				return
+			}
+
+			pkg.PackageExternalReferences = append(pkg.PackageExternalReferences, &spdx_2_3.PackageExternalReference{
+				Category: spdx.CategoryOther,
+				RefType:  "osvdatabase",
+				Locator:  "https://api.osv.dev/v1/query",
+				ExternalRefComment:  vuln_report,
+			})
+		}(pkg, i)
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
Hi,

This PR adds `osv` to the list of supported actions. When called like `cat testing/sbom.spdx-2.3.json | ./parlay osv enrich -`, this will enrich SBOMs with data from the Open Source Vulnerabilities database, listing vulnerabilities known to affect the software.

Since the OSV API uses POST requests instead of GET, the usual structure for external references didn't quite seem to work since there's no place to store the POST body. So instead, this code stores the full responses in a comment field, using an osv-wrapper project I wrote that adds some redundancy to the lookup methods.

I would love some tips on how to write a good test suite for this! It'd probably be a good idea to add that before merging, but I wanted to get the conversation started. Please give it a try and let me know if there's anything I can update to make it more useful!

Thanks!