### PR TITLE
feat: add User-Agent header to ecosyste.ms API requests

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,6 +23,7 @@ builds:
   - "-s"
   - "-w"
   - "-X github.com/snyk/parlay/internal/commands.version={{.Version}}"
+  - "-X github.com/snyk/parlay/lib/ecosystems.Version={{.Version}}"
 
 archives:
 - format: tar.gz

--- a/lib/ecosystems/package.go
+++ b/lib/ecosystems/package.go
@@ -19,6 +19,7 @@ package ecosystems
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/package-url/packageurl-go"
 
@@ -27,8 +28,19 @@ import (
 
 const server = "https://packages.ecosyste.ms/api/v1"
 
+// Version will be set by the build process
+var Version = "dev"
+
+func getUserAgent() string {
+	return fmt.Sprintf("Parlay (%s)", Version)
+}
+
 func GetPackageData(purl packageurl.PackageURL) (*packages.GetRegistryPackageResponse, error) {
-	client, err := packages.NewClientWithResponses(server)
+	client, err := packages.NewClientWithResponses(server,
+		packages.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
+			req.Header.Set("User-Agent", getUserAgent())
+			return nil
+		}))
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +56,11 @@ func GetPackageData(purl packageurl.PackageURL) (*packages.GetRegistryPackageRes
 }
 
 func GetPackageVersionData(purl packageurl.PackageURL) (*packages.GetRegistryPackageVersionResponse, error) {
-	client, err := packages.NewClientWithResponses(server)
+	client, err := packages.NewClientWithResponses(server,
+		packages.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
+			req.Header.Set("User-Agent", getUserAgent())
+			return nil
+		}))
 	if err != nil {
 		return nil, err
 	}

--- a/lib/ecosystems/package_test.go
+++ b/lib/ecosystems/package_test.go
@@ -18,6 +18,7 @@ package ecosystems
 
 import (
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/jarcoal/httpmock"
@@ -45,6 +46,57 @@ func TestGetPackageData(t *testing.T) {
 	httpmock.GetTotalCallCount()
 	calls := httpmock.GetCallCountInfo()
 	assert.Equal(t, 1, calls[`GET =~^https://packages.ecosyste.ms/api/v1/registries`])
+}
+
+func TestGetPackageDataUserAgent(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	var capturedUserAgent string
+	httpmock.RegisterResponder(
+		"GET",
+		`=~^https://packages.ecosyste.ms/api/v1/registries`,
+		func(req *http.Request) (*http.Response, error) {
+			capturedUserAgent = req.Header.Get("User-Agent")
+			return httpmock.NewBytesResponse(200, []byte{}), nil
+		},
+	)
+
+	purl, err := packageurl.FromString("pkg:npm/lodash@4.17.21")
+	require.NoError(t, err)
+
+	_, err = GetPackageData(purl)
+	require.NoError(t, err)
+
+	expectedUserAgent := fmt.Sprintf("Parlay (%s)", Version)
+	assert.Equal(t, expectedUserAgent, capturedUserAgent)
+	// Verify it contains "Parlay" and the version in parentheses
+	assert.Contains(t, capturedUserAgent, "Parlay")
+	assert.Contains(t, capturedUserAgent, "(")
+	assert.Contains(t, capturedUserAgent, ")")
+}
+
+func TestGetPackageVersionDataUserAgent(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	var capturedUserAgent string
+	httpmock.RegisterResponder(
+		"GET",
+		`=~^https://packages.ecosyste.ms/api/v1/registries`,
+		func(req *http.Request) (*http.Response, error) {
+			capturedUserAgent = req.Header.Get("User-Agent")
+			return httpmock.NewBytesResponse(200, []byte{}), nil
+		},
+	)
+
+	purl, err := packageurl.FromString("pkg:npm/lodash@4.17.21")
+	require.NoError(t, err)
+
+	_, err = GetPackageVersionData(purl)
+	require.NoError(t, err)
+
+	assert.Equal(t, fmt.Sprintf("Parlay (%s)", Version), capturedUserAgent)
 }
 
 func TestPurlToEcosystemsRegistry(t *testing.T) {

--- a/lib/ecosystems/repo.go
+++ b/lib/ecosystems/repo.go
@@ -18,6 +18,7 @@ package ecosystems
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/snyk/parlay/ecosystems/repos"
 )
@@ -25,7 +26,11 @@ import (
 const repos_server = "https://repos.ecosyste.ms/api/v1"
 
 func GetRepoData(url string) (*repos.RepositoriesLookupResponse, error) {
-	client, err := repos.NewClientWithResponses(repos_server)
+	client, err := repos.NewClientWithResponses(repos_server,
+		repos.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
+			req.Header.Set("User-Agent", getUserAgent())
+			return nil
+		}))
 	if err != nil {
 		return nil, err
 	}

--- a/lib/ecosystems/repo_test.go
+++ b/lib/ecosystems/repo_test.go
@@ -17,6 +17,8 @@
 package ecosystems
 
 import (
+	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/jarcoal/httpmock"
@@ -40,4 +42,24 @@ func TestGetRepoData(t *testing.T) {
 	httpmock.GetTotalCallCount()
 	calls := httpmock.GetCallCountInfo()
 	assert.Equal(t, 1, calls["GET https://repos.ecosyste.ms/api/v1/repositories/lookup"])
+}
+
+func TestGetRepoDataUserAgent(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	var capturedUserAgent string
+	httpmock.RegisterResponder(
+		"GET",
+		"https://repos.ecosyste.ms/api/v1/repositories/lookup",
+		func(req *http.Request) (*http.Response, error) {
+			capturedUserAgent = req.Header.Get("User-Agent")
+			return httpmock.NewBytesResponse(200, []byte{}), nil
+		},
+	)
+
+	_, err := GetRepoData("https://github.com/golang/go")
+	require.NoError(t, err)
+
+	assert.Equal(t, fmt.Sprintf("Parlay (%s)", Version), capturedUserAgent)
 }


### PR DESCRIPTION
To help me better understand how people are using the ecosyste.ms apis, I'm trying to get popular clients to send a unique user agent when sending http requests to the various apis.

I've add a version specifier in as well, but I'm not that familiar with Go so if there's a better way to do it then let me know and I'll adjust it.