### PR TITLE
feat: add local cache to sbom enrichment

### DIFF
--- a/lib/ecosystems/cache.go
+++ b/lib/ecosystems/cache.go
@@ -1,0 +1,93 @@
+/*
+ * © 2023 Snyk Limited All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ecosystems
+
+import (
+	"sync"
+
+	"github.com/package-url/packageurl-go"
+
+	"github.com/snyk/parlay/ecosystems/packages"
+)
+
+type Cache interface {
+	GetPackageData(purl packageurl.PackageURL) (*packages.GetRegistryPackageResponse, error)
+	GetPackageVersionData(purl packageurl.PackageURL) (*packages.GetRegistryPackageVersionResponse, error)
+}
+
+type InMemoryCache struct {
+	packageCache        map[string]*packages.GetRegistryPackageResponse
+	packageVersionCache map[string]*packages.GetRegistryPackageVersionResponse
+	mu                  sync.RWMutex
+}
+
+func NewInMemoryCache() *InMemoryCache {
+	return &InMemoryCache{
+		packageCache:        make(map[string]*packages.GetRegistryPackageResponse),
+		packageVersionCache: make(map[string]*packages.GetRegistryPackageVersionResponse),
+	}
+}
+
+func (c *InMemoryCache) GetPackageData(purl packageurl.PackageURL) (*packages.GetRegistryPackageResponse, error) {
+	key := purl.ToString()
+
+	c.mu.RLock()
+	if cached, exists := c.packageCache[key]; exists {
+		c.mu.RUnlock()
+		return cached, nil
+	}
+	c.mu.RUnlock()
+
+	response, err := GetPackageData(purl)
+	if err != nil {
+		return nil, err
+	}
+
+	c.mu.Lock()
+	c.packageCache[key] = response
+	c.mu.Unlock()
+
+	return response, nil
+}
+
+func (c *InMemoryCache) GetPackageVersionData(purl packageurl.PackageURL) (*packages.GetRegistryPackageVersionResponse, error) {
+	key := purl.ToString()
+
+	c.mu.RLock()
+	if cached, exists := c.packageVersionCache[key]; exists {
+		c.mu.RUnlock()
+		return cached, nil
+	}
+	c.mu.RUnlock()
+
+	response, err := GetPackageVersionData(purl)
+	if err != nil {
+		return nil, err
+	}
+
+	c.mu.Lock()
+	c.packageVersionCache[key] = response
+	c.mu.Unlock()
+
+	return response, nil
+}
+
+func (c *InMemoryCache) GetCacheStats() (int, int) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.packageCache), len(c.packageVersionCache)
+}

--- a/lib/ecosystems/cache_test.go
+++ b/lib/ecosystems/cache_test.go
@@ -1,0 +1,224 @@
+/*
+ * © 2023 Snyk Limited All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ecosystems
+
+import (
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/package-url/packageurl-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInMemoryCache_GetPackageData(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	mockResponse := `{"name": "test-package", "description": "Test package"}`
+	httpmock.RegisterResponder(
+		"GET",
+		`=~^https://packages.ecosyste.ms/api/v1/registries`,
+		httpmock.NewStringResponder(200, mockResponse),
+	)
+
+	cache := NewInMemoryCache()
+	purl, err := packageurl.FromString("pkg:npm/test-package@1.0.0")
+	require.NoError(t, err)
+
+	resp1, err := cache.GetPackageData(purl)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp1)
+
+	resp2, err := cache.GetPackageData(purl)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp2)
+	assert.Equal(t, resp1, resp2)
+
+	callCount := httpmock.GetTotalCallCount()
+	assert.Equal(t, 1, callCount)
+
+	pkgCacheSize, versionCacheSize := cache.GetCacheStats()
+	assert.Equal(t, 1, pkgCacheSize)
+	assert.Equal(t, 0, versionCacheSize)
+}
+
+func TestInMemoryCache_GetPackageVersionData(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	mockResponse := `{"number": "1.0.0", "licenses": "MIT"}`
+	httpmock.RegisterResponder(
+		"GET",
+		`=~^https://packages.ecosyste.ms/api/v1/registries`,
+		httpmock.NewStringResponder(200, mockResponse),
+	)
+
+	cache := NewInMemoryCache()
+	purl, err := packageurl.FromString("pkg:npm/test-package@1.0.0")
+	require.NoError(t, err)
+
+	resp1, err := cache.GetPackageVersionData(purl)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp1)
+
+	resp2, err := cache.GetPackageVersionData(purl)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp2)
+	assert.Equal(t, resp1, resp2)
+
+	callCount := httpmock.GetTotalCallCount()
+	assert.Equal(t, 1, callCount)
+
+	pkgCacheSize, versionCacheSize := cache.GetCacheStats()
+	assert.Equal(t, 0, pkgCacheSize)
+	assert.Equal(t, 1, versionCacheSize)
+}
+
+func TestInMemoryCache_DifferentPackages(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder(
+		"GET",
+		`=~^https://packages.ecosyste.ms/api/v1/registries`,
+		httpmock.NewStringResponder(200, `{}`),
+	)
+
+	cache := NewInMemoryCache()
+	purl1, err := packageurl.FromString("pkg:npm/package1@1.0.0")
+	require.NoError(t, err)
+	purl2, err := packageurl.FromString("pkg:npm/package2@1.0.0")
+	require.NoError(t, err)
+
+	_, err = cache.GetPackageData(purl1)
+	assert.NoError(t, err)
+	_, err = cache.GetPackageData(purl2)
+	assert.NoError(t, err)
+
+	callCount := httpmock.GetTotalCallCount()
+	assert.Equal(t, 2, callCount)
+
+	pkgCacheSize, versionCacheSize := cache.GetCacheStats()
+	assert.Equal(t, 2, pkgCacheSize)
+	assert.Equal(t, 0, versionCacheSize)
+}
+
+func TestInMemoryCache_SamePackageDifferentVersions(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder(
+		"GET",
+		`=~^https://packages.ecosyste.ms/api/v1/registries`,
+		httpmock.NewStringResponder(200, `{}`),
+	)
+
+	cache := NewInMemoryCache()
+	purl1, err := packageurl.FromString("pkg:npm/package@1.0.0")
+	require.NoError(t, err)
+	purl2, err := packageurl.FromString("pkg:npm/package@2.0.0")
+	require.NoError(t, err)
+
+	_, err = cache.GetPackageData(purl1)
+	assert.NoError(t, err)
+	_, err = cache.GetPackageData(purl2)
+	assert.NoError(t, err)
+
+	// Different versions = different cache entries
+	callCount := httpmock.GetTotalCallCount()
+	assert.Equal(t, 2, callCount)
+
+	pkgCacheSize, versionCacheSize := cache.GetCacheStats()
+	assert.Equal(t, 2, pkgCacheSize)
+	assert.Equal(t, 0, versionCacheSize)
+}
+
+func TestInMemoryCache_APIError(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	// HTTP client returns a successful response even with 500 status
+	// So we need to test that the client properly handles this case
+	httpmock.RegisterResponder(
+		"GET",
+		`=~^https://packages.ecosyste.ms/api/v1/registries`,
+		httpmock.NewStringResponder(500, `{"error": "internal server error"}`),
+	)
+
+	cache := NewInMemoryCache()
+	purl, err := packageurl.FromString("pkg:npm/test-package@1.0.0")
+	require.NoError(t, err)
+
+	// HTTP client doesn't treat 500 as error
+	resp1, err := cache.GetPackageData(purl)
+	assert.NoError(t, err)
+	assert.Equal(t, 500, resp1.StatusCode())
+
+	resp2, err := cache.GetPackageData(purl)
+	assert.NoError(t, err)
+	assert.Equal(t, 500, resp2.StatusCode())
+	assert.Equal(t, resp1, resp2)
+
+	// Second call used cache
+	callCount := httpmock.GetTotalCallCount()
+	assert.Equal(t, 1, callCount)
+
+	pkgCacheSize, versionCacheSize := cache.GetCacheStats()
+	assert.Equal(t, 1, pkgCacheSize)
+	assert.Equal(t, 0, versionCacheSize)
+}
+
+func TestInMemoryCache_ConcurrentAccess(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder(
+		"GET",
+		`=~^https://packages.ecosyste.ms/api/v1/registries`,
+		httpmock.NewStringResponder(200, `{}`),
+	)
+
+	cache := NewInMemoryCache()
+	purl, err := packageurl.FromString("pkg:npm/test-package@1.0.0")
+	require.NoError(t, err)
+
+	done := make(chan bool)
+	numGoroutines := 10
+
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			_, err := cache.GetPackageData(purl)
+			assert.NoError(t, err)
+			done <- true
+		}()
+	}
+
+	for i := 0; i < numGoroutines; i++ {
+		<-done
+	}
+
+	// Should only have one entry despite concurrent access
+	pkgCacheSize, versionCacheSize := cache.GetCacheStats()
+	assert.Equal(t, 1, pkgCacheSize)
+	assert.Equal(t, 0, versionCacheSize)
+
+	// API should have been called at least once, but maybe more due to race conditions
+	// can't guarantee exactly 1 call due to concurrent access, but it should at least less than 10
+	callCount := httpmock.GetTotalCallCount()
+	assert.True(t, callCount >= 1 && callCount <= numGoroutines)
+}

--- a/lib/ecosystems/enrich_spdx.go
+++ b/lib/ecosystems/enrich_spdx.go
@@ -35,13 +35,15 @@ func enrichSPDX(bom *spdx.Document, logger *zerolog.Logger) {
 
 	logger.Debug().Msgf("Detected %d packages", len(packages))
 
+	cache := NewInMemoryCache()
+
 	for _, pkg := range packages {
 		purl, err := extractPurl(pkg)
 		if err != nil {
 			continue
 		}
 
-		packageResp, err := GetPackageData(*purl)
+		packageResp, err := cache.GetPackageData(*purl)
 		if err != nil {
 			continue
 		}
@@ -55,7 +57,7 @@ func enrichSPDX(bom *spdx.Document, logger *zerolog.Logger) {
 		enrichSPDXHomepage(pkg, pkgData)
 		enrichSPDXSupplier(pkg, pkgData)
 
-		packageVersionResp, err := GetPackageVersionData(*purl)
+		packageVersionResp, err := cache.GetPackageVersionData(*purl)
 		if err != nil {
 			continue
 		}

--- a/lib/ecosystems/enrich_spdx_test.go
+++ b/lib/ecosystems/enrich_spdx_test.go
@@ -116,6 +116,99 @@ func TestEnrichSBOM_SPDX(t *testing.T) {
 	require.NoError(t, doc.Encode(buf))
 }
 
+func TestEnrichSBOM_SPDX_WithDuplicates(t *testing.T) {
+	packageVersionResponse := `{
+		"licenses": "MIT"
+	}`
+	packageResponse := `{
+		"description": "description",
+		"normalized_licenses": ["BSD-3-Clause"],
+		"homepage": "https://github.com/spdx/tools-golang",
+		"repo_metadata": {
+			"owner_record": {
+				"name": "Acme Corp"
+			}
+		}
+	}`
+	setupHttpmock(t, &packageVersionResponse, &packageResponse)
+	defer httpmock.DeactivateAndReset()
+
+	doc, err := sbom.DecodeSBOMDocument([]byte(`{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT"}`))
+	require.NoError(t, err)
+
+	bom, ok := doc.BOM.(*v2_3.Document)
+	require.True(t, ok)
+
+	// Create SBOM with duplicate packages to test caching
+	bom.Packages = []*v2_3.Package{
+		{
+			PackageSPDXIdentifier: "pkg:golang/github.com/spdx/tools-golang@v0.5.2",
+			PackageName:           "github.com/spdx/tools-golang",
+			PackageVersion:        "v0.5.2",
+			PackageExternalReferences: []*v2_3.PackageExternalReference{
+				{
+					Category: common.CategoryPackageManager,
+					RefType:  "purl",
+					Locator:  "pkg:golang/github.com/spdx/tools-golang@v0.5.2",
+				},
+			},
+		},
+		{
+			PackageSPDXIdentifier: "pkg:golang/github.com/spdx/tools-golang@v0.5.2-duplicate",
+			PackageName:           "github.com/spdx/tools-golang",
+			PackageVersion:        "v0.5.2",
+			PackageExternalReferences: []*v2_3.PackageExternalReference{
+				{
+					Category: common.CategoryPackageManager,
+					RefType:  "purl",
+					Locator:  "pkg:golang/github.com/spdx/tools-golang@v0.5.2",
+				},
+			},
+		},
+		{
+			PackageSPDXIdentifier: "pkg:npm/lodash@4.17.21",
+			PackageName:           "lodash",
+			PackageVersion:        "4.17.21",
+			PackageExternalReferences: []*v2_3.PackageExternalReference{
+				{
+					Category: common.CategoryPackageManager,
+					RefType:  "purl",
+					Locator:  "pkg:npm/lodash@4.17.21",
+				},
+			},
+		},
+	}
+	logger := zerolog.Nop()
+
+	EnrichSBOM(doc, &logger)
+
+	pkgs := bom.Packages
+
+	// Verify both duplicate packages are enriched correctly
+	assert.Equal(t, "description", pkgs[0].PackageDescription)
+	assert.Equal(t, "MIT", pkgs[0].PackageLicenseConcluded)
+	assert.Equal(t, "https://github.com/spdx/tools-golang", pkgs[0].PackageHomePage)
+	assert.Equal(t, "Organization", pkgs[0].PackageSupplier.SupplierType)
+	assert.Equal(t, "Acme Corp", pkgs[0].PackageSupplier.Supplier)
+
+	assert.Equal(t, "description", pkgs[1].PackageDescription)
+	assert.Equal(t, "MIT", pkgs[1].PackageLicenseConcluded)
+	assert.Equal(t, "https://github.com/spdx/tools-golang", pkgs[1].PackageHomePage)
+	assert.Equal(t, "Organization", pkgs[1].PackageSupplier.SupplierType)
+	assert.Equal(t, "Acme Corp", pkgs[1].PackageSupplier.Supplier)
+
+	// Verify caching worked: should have made only 4 API calls instead of 6
+	// (2 calls for unique golang package + 2 calls for unique npm package)
+	httpmock.GetTotalCallCount()
+	calls := httpmock.GetCallCountInfo()
+	packageCalls := calls[`GET =~^https://packages.ecosyste.ms/api/v1/registries`]
+	versionCalls := calls[`GET =~^https://packages.ecosyste.ms/api/v1/registries/.*/packages/.*/versions`]
+	totalCalls := packageCalls + versionCalls
+	// Without caching, it would make 6 calls (3 packages * 2 calls each)
+	// With caching, it should make 4 calls (2 unique packages * 2 calls each)
+	assert.Equal(t, 4, totalCalls)
+}
+
 func TestEnrichSBOM_MissingVersionedLicense(t *testing.T) {
 	packageVersionResponse := `{
 		"licenses": ""


### PR DESCRIPTION
Add in-memory caching for ecosyste.ms API calls during SBOM enrichment to improve performance when processing SBOMs with duplicate packages. Uses a thread-safe cache with sync.RWMutex with each SBOM getting a fresh cache instance.

closes https://github.com/snyk/parlay/issues/112