### PR TITLE
fix: reuse ecosyste.ms cache across SBOM enrichments

### DIFF
--- a/lib/ecosystems/enrich_cyclonedx.go
+++ b/lib/ecosystems/enrich_cyclonedx.go
@@ -197,7 +197,7 @@ func enrichCDXTopics(comp *cdx.Component, data *packages.Package) {
 
 func enrichCDX(bom *cdx.BOM, logger *zerolog.Logger) {
 	wg := sizedwaitgroup.New(20)
-	cache := NewInMemoryCache()
+	cache := GetGlobalCache()
 
 	comps := utils.DiscoverCDXComponents(bom)
 	logger.Debug().Msgf("Detected %d packages", len(comps))

--- a/lib/ecosystems/enrich_cyclonedx_test.go
+++ b/lib/ecosystems/enrich_cyclonedx_test.go
@@ -132,6 +132,7 @@ func TestEnrichSBOM_CycloneDX_NestedComps(t *testing.T) {
 }
 
 func TestEnrichSBOMWithoutLicense(t *testing.T) {
+	ResetGlobalCache()
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 

--- a/lib/ecosystems/enrich_spdx.go
+++ b/lib/ecosystems/enrich_spdx.go
@@ -35,7 +35,7 @@ func enrichSPDX(bom *spdx.Document, logger *zerolog.Logger) {
 
 	logger.Debug().Msgf("Detected %d packages", len(packages))
 
-	cache := NewInMemoryCache()
+	cache := GetGlobalCache()
 
 	for _, pkg := range packages {
 		purl, err := extractPurl(pkg)

--- a/lib/ecosystems/enrich_spdx_test.go
+++ b/lib/ecosystems/enrich_spdx_test.go
@@ -117,6 +117,7 @@ func TestEnrichSBOM_SPDX(t *testing.T) {
 }
 
 func TestEnrichSBOM_MissingVersionedLicense(t *testing.T) {
+	ResetGlobalCache()
 	packageVersionResponse := `{
 		"licenses": ""
 	}`


### PR DESCRIPTION
Note: I used claude code to generate this as I'm not experienced with Go, feel free to edit or completely rewrite if you wish. I noticed that there's a lot of repeated 404 requests from parlay within the same time period in the ecosyste.ms logs, I sent claude to investigate and this is what it came up with.

Previously, each SBOM enrichment created a new cache instance, causing repeated API calls for the same packages (including 404s for non-existent packages). This change introduces a global cache singleton that persists for the lifetime of the process, reducing unnecessary API calls to ecosyste.ms.


