### PR TITLE
feat: add parlay user-agent in snyk API calls

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
   - "-w"
   - "-X github.com/snyk/parlay/internal/commands.version={{.Version}}"
   - "-X github.com/snyk/parlay/lib/ecosystems.Version={{.Version}}"
+  - "-X github.com/snyk/parlay/lib/snyk.Version={{.Version}}"
 
 archives:
 - format: tar.gz

--- a/lib/snyk/config.go
+++ b/lib/snyk/config.go
@@ -16,6 +16,15 @@
 
 package snyk
 
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// Version will be set by the build process
+var Version = "dev"
+
 type Config struct {
 	SnykAPIURL string
 	APIToken   string
@@ -25,4 +34,13 @@ func DefaultConfig() *Config {
 	return &Config{
 		SnykAPIURL: "https://api.snyk.io",
 	}
+}
+
+func getUserAgent() string {
+	return fmt.Sprintf("parlay (%s)", Version)
+}
+
+func addParlayUserAgent(ctx context.Context, req *http.Request) error {
+	req.Header.Set("User-Agent", getUserAgent())
+	return nil
 }

--- a/lib/snyk/package.go
+++ b/lib/snyk/package.go
@@ -90,6 +90,7 @@ func GetPackageVulnerabilities(cfg *Config, purl *packageurl.PackageURL, auth *s
 	client, err := issues.NewClientWithResponses(
 		cfg.SnykAPIURL+"/rest",
 		issues.WithRequestEditorFn(auth.Intercept),
+		issues.WithRequestEditorFn(addParlayUserAgent),
 		issues.WithHTTPClient(getRetryClient(logger)))
 	if err != nil {
 		return nil, err

--- a/lib/snyk/package_test.go
+++ b/lib/snyk/package_test.go
@@ -89,3 +89,24 @@ func TestGetPackageVulnerabilities_HandlesNilResponses(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, issues)
 }
+
+func TestGetPackageVulnerabilities_SetsUserAgent(t *testing.T) {
+	logger := zerolog.Nop()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.Header.Get("User-Agent"), "parlay")
+	}))
+	defer srv.Close()
+
+	cfg := DefaultConfig()
+	cfg.SnykAPIURL = srv.URL
+
+	auth, err := AuthFromToken("asdf")
+	require.NoError(t, err)
+
+	purl, err := packageurl.FromString("pkg:golang/github.com/snyk/parlay")
+	require.NoError(t, err)
+
+	orgID := uuid.New()
+	_, err = GetPackageVulnerabilities(cfg, &purl, auth, &orgID, &logger)
+	require.NoError(t, err)
+}

--- a/lib/snyk/self.go
+++ b/lib/snyk/self.go
@@ -33,7 +33,8 @@ const experimentalVersion = "2023-04-28~experimental"
 func SnykOrgID(cfg *Config, auth *securityprovider.SecurityProviderApiKey) (*uuid.UUID, error) {
 	experimental, err := users.NewClientWithResponses(
 		cfg.SnykAPIURL+"/rest",
-		users.WithRequestEditorFn(auth.Intercept))
+		users.WithRequestEditorFn(auth.Intercept),
+		users.WithRequestEditorFn(addParlayUserAgent))
 	if err != nil {
 		return nil, err
 	}

--- a/lib/snyk/self_test.go
+++ b/lib/snyk/self_test.go
@@ -65,3 +65,19 @@ func TestSnykOrgID_Unauthorized(t *testing.T) {
 	assert.ErrorContains(t, err, "Failed to get user info (401 Unauthorized)")
 	assert.Nil(t, actualOrg)
 }
+
+func TestSnykOrgID_SetsUserAgent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.Header.Get("User-Agent"), "parlay")
+		respond(w, selfBody)
+	}))
+	defer srv.Close()
+
+	cfg := DefaultConfig()
+	cfg.SnykAPIURL = srv.URL
+	auth, err := securityprovider.NewSecurityProviderApiKey("header", "authorization", "asdf")
+	require.NoError(t, err)
+
+	_, err = SnykOrgID(cfg, auth)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Adds user agent header `parlay (<version>)` to Snyk API  requests.