### PR TITLE
build: upgrade to Go 1.25 and golangci-lint 2.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 go_image: &go_image
   resource_class: small
   docker:
-    - image: cimg/go:1.23
+    - image: cimg/go:1.25
 
 jobs:
   security-scans:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,12 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.23.2
+        go-version: '1.25'
 
     - name: Lint
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v9
+      with:
+        version: v2.9.0
 
     - name: Build
       run: go build -v -o parlay

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.23
+          go-version: '1.25'
           check-latest: true
       - run: go version
       - name: Install Syft

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.23
+        go-version: '1.25'
 
     - uses: snyk/actions/setup@master
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,30 +1,44 @@
+version: "2"
 run:
   issues-exit-code: 1
-  color: always
-  max-same-issues: 0
-  max-issues-per-linter: 0
   tests: true
-  timeout: 5m
-
 linters:
   enable:
-    - errcheck
-    - goimports
-    - gosimple
-    - govet
-    - ineffassign
     - misspell
-    - staticcheck
-    - typecheck
-    - unused
-
-linters-settings:
-  errcheck:
-    check-blank: true
-    check-type-assertions: true
-  govet:
-    check-shadowing: true
-  goimports:
-    local-prefixes: github.com/snyk/parlay
-  misspell:
-    locale: US
+  settings:
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+    govet:
+      enable:
+        - shadow
+    misspell:
+      locale: US
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - staticcheck
+        text: "ST1005:"
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/snyk/parlay
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snyk/parlay
 
-go 1.23
+go 1.25.7
 
 require (
 	github.com/CycloneDX/cyclonedx-go v0.9.2


### PR DESCRIPTION
This PR:
* Bumps the Go version to 1.25 to address some vulns in the standard library e.g. [SNYK-GOLANG-STDNETURL-15139468](https://security.snyk.io/vuln/SNYK-GOLANG-STDNETURL-15139468)
* Bumps the golangci-lint version to the latest 2.x version, as there are no longer any 1.x golangci-lint Docker images that support Go 1.25, and migrates the config accordingly
* Updates GitHub Actions workflow Go versions and upgrades golangci-lint-action to v9
* Fixes or ignores linting errors newly caught by the above change