### PR TITLE
build: upgrade go to 1.26.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 go_image: &go_image
   resource_class: small
   docker:
-    - image: cimg/go:1.25
+    - image: cimg/go:1.26.3
 
 jobs:
   security-scans:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.25'
+        go-version: '1.26.3'
 
     - name: Lint
       uses: golangci/golangci-lint-action@v9

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.25'
+          go-version: '1.26.3'
           check-latest: true
       - run: go version
       - name: Install Syft

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.25'
+        go-version: '1.26.3'
 
     - uses: snyk/actions/setup@master
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snyk/parlay
 
-go 1.25.7
+go 1.26.3
 
 require (
 	github.com/CycloneDX/cyclonedx-go v0.9.2


### PR DESCRIPTION
### Summary

- `go.mod` directive: 1.25.7 → 1.26.3.
- `go-version` pin in `ci.yml`, `release.yml`, and `security.yml` workflows: 1.25 → 1.26.

### Why

Clears 4 high-sev stdlib vulns flagged by Snyk:
- `std/net` — fixed in 1.25.10 / 1.26.3
- `std/net/http` — fixed in 1.25.10 / 1.26.3
- `std/crypto/tls` — fixed in 1.25.9 / 1.26.2