### PR TITLE
feat: populate component hashes from ecosyste.ms integrity field

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ parlay ecosystems repo https://github.com/open-policy-agent/conftest
 
 ### Component hashes
 
-parlay populates per-component hashes (CycloneDX `component.hashes[]` and SPDX `package.checksums[]`) from the ecosyste.ms `integrity` field. This is currently available for registries that publish a distribution digest — including PyPI, npm, RubyGems, Cargo, and Composer. Registries without an `integrity` value (today: Go modules and Maven Central) are left untouched. Existing hashes already on the component, such as the container-layer hashes that `syft` emits, are preserved.
+parlay populates per-component hashes (CycloneDX `component.hashes[]` and SPDX `package.checksums[]`) from the ecosyste.ms `integrity` field. This is currently available for registries that publish a distribution digest via ecosyste.ms — today: PyPI, npm, and RubyGems. Registries where ecosyste.ms does not surface an integrity value (including Go modules, Maven Central, Cargo, and Packagist) are left untouched. Existing hashes already on the component, such as the container-layer hashes that `syft` emits, are preserved.
 
 ### License data
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ You can also return raw JSON information about a specific repository:
 parlay ecosystems repo https://github.com/open-policy-agent/conftest
 ```
 
+### Component hashes
+
+parlay populates per-component hashes (CycloneDX `component.hashes[]` and SPDX `package.checksums[]`) from the ecosyste.ms `integrity` field. This is currently available for registries that publish a distribution digest — including PyPI, npm, RubyGems, Cargo, and Composer. Registries without an `integrity` value (today: Go modules and Maven Central) are left untouched. Existing hashes already on the component, such as the container-layer hashes that `syft` emits, are preserved.
+
 ### License data
 
 parlay enriches components and packages with their license information from ecosyste.ms on a best-effort basis. It prefers the license data of the package version at hand; however, it may not always be possible to retrieve the license for a specific version (see [ecosyste.ms issue here](https://github.com/ecosyste-ms/packages/issues/1027) for more info). In this case, parlay will fall back to enriching with the license data of the package's latest release. In rare cases — where the licensing model of a package changed over time — this may result in license data inaccuracies.

--- a/lib/ecosystems/enrich_cyclonedx.go
+++ b/lib/ecosystems/enrich_cyclonedx.go
@@ -68,6 +68,28 @@ func enrichCDXLicense(comp *cdx.Component, pkgVersionData *packages.VersionWithD
 	}
 }
 
+// enrichCDXHash appends a Hash derived from ecosyste.ms' per-version
+// integrity field. Existing hashes (e.g. container-layer hashes added by
+// syft) are preserved.
+func enrichCDXHash(comp *cdx.Component, pkgVersionData *packages.VersionWithDependencies, _ *packages.Package, logger *zerolog.Logger) {
+	if pkgVersionData.Integrity == nil {
+		return
+	}
+	alg, _, value, ok := parseIntegrity(*pkgVersionData.Integrity)
+	if !ok {
+		logger.Debug().
+			Str("integrity", *pkgVersionData.Integrity).
+			Msg("Skipping hash enrichment: unrecognised integrity format")
+		return
+	}
+	hash := cdx.Hash{Algorithm: alg, Value: value}
+	if comp.Hashes == nil {
+		comp.Hashes = &[]cdx.Hash{hash}
+	} else {
+		*comp.Hashes = append(*comp.Hashes, hash)
+	}
+}
+
 func enrichExternalReference(comp *cdx.Component, ref *string, refType cdx.ExternalReferenceType) {
 	if ref == nil {
 		return
@@ -253,6 +275,7 @@ func enrichCDX(bom *cdx.BOM, logger *zerolog.Logger) {
 			for _, enrichFunc := range cdxPackageVersionEnrichers {
 				enrichFunc(comp, packageVersionResp.JSON200, packageResp.JSON200)
 			}
+			enrichCDXHash(comp, packageVersionResp.JSON200, packageResp.JSON200, &l)
 		}(comps[i])
 	}
 

--- a/lib/ecosystems/enrich_cyclonedx.go
+++ b/lib/ecosystems/enrich_cyclonedx.go
@@ -52,6 +52,7 @@ var cdxPackageEnrichers = []cdxPackageEnricher{
 
 var cdxPackageVersionEnrichers = []cdxPackageVersionEnricher{
 	enrichCDXLicense,
+	enrichCDXHash,
 }
 
 func enrichCDXDescription(comp *cdx.Component, data *packages.Package) {
@@ -71,15 +72,12 @@ func enrichCDXLicense(comp *cdx.Component, pkgVersionData *packages.VersionWithD
 // enrichCDXHash appends a Hash derived from ecosyste.ms' per-version
 // integrity field. Existing hashes (e.g. container-layer hashes added by
 // syft) are preserved.
-func enrichCDXHash(comp *cdx.Component, pkgVersionData *packages.VersionWithDependencies, _ *packages.Package, logger *zerolog.Logger) {
+func enrichCDXHash(comp *cdx.Component, pkgVersionData *packages.VersionWithDependencies, _ *packages.Package) {
 	if pkgVersionData.Integrity == nil {
 		return
 	}
 	alg, _, value, ok := parseIntegrity(*pkgVersionData.Integrity)
 	if !ok {
-		logger.Debug().
-			Str("integrity", *pkgVersionData.Integrity).
-			Msg("Skipping hash enrichment: unrecognised integrity format")
 		return
 	}
 	hash := cdx.Hash{Algorithm: alg, Value: value}
@@ -275,7 +273,6 @@ func enrichCDX(bom *cdx.BOM, logger *zerolog.Logger) {
 			for _, enrichFunc := range cdxPackageVersionEnrichers {
 				enrichFunc(comp, packageVersionResp.JSON200, packageResp.JSON200)
 			}
-			enrichCDXHash(comp, packageVersionResp.JSON200, packageResp.JSON200, &l)
 		}(comps[i])
 	}
 

--- a/lib/ecosystems/enrich_cyclonedx_test.go
+++ b/lib/ecosystems/enrich_cyclonedx_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jarcoal/httpmock"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/snyk/parlay/ecosystems/packages"
 	"github.com/snyk/parlay/lib/sbom"
@@ -240,6 +241,104 @@ func TestEnrichLicenseNoLatestLicense(t *testing.T) {
 	comp := cdx.LicenseChoice(cdx.LicenseChoice{Expression: "(BSD-3-Clause)"})
 	assert.Equal(t, 1, len(licenses))
 	assert.Equal(t, comp, licenses[0])
+}
+
+func TestEnrichSBOM_CycloneDX_PopulatesHashFromIntegrity(t *testing.T) {
+	ResetGlobalCache()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("GET", `=~^https://packages.ecosyste.ms/api/v1/registries/.*/packages/.*/versions`,
+		func(r *http.Request) (*http.Response, error) {
+			return httpmock.NewJsonResponse(200, map[string]any{
+				"integrity": "sha256-17ea4276b66cf0ecf3a8f10df1e34d40fe26be590ca1e25b1c33a0ff05451631",
+			})
+		},
+	)
+	httpmock.RegisterResponder("GET", `=~^https://packages.ecosyste.ms/api/v1/registries`,
+		func(req *http.Request) (*http.Response, error) {
+			return httpmock.NewJsonResponse(200, map[string]any{})
+		})
+
+	bom := &cdx.BOM{
+		Components: &[]cdx.Component{
+			{
+				BOMRef:     "pkg:pypi/fastapi@0.115.0",
+				Type:       cdx.ComponentTypeLibrary,
+				Name:       "fastapi",
+				Version:    "0.115.0",
+				PackageURL: "pkg:pypi/fastapi@0.115.0",
+			},
+		},
+	}
+	doc := &sbom.SBOMDocument{BOM: bom}
+	logger := zerolog.Nop()
+
+	EnrichSBOM(doc, &logger)
+
+	hashes := (*bom.Components)[0].Hashes
+	require.NotNil(t, hashes)
+	assert.Equal(t, []cdx.Hash{
+		{
+			Algorithm: cdx.HashAlgoSHA256,
+			Value:     "17ea4276b66cf0ecf3a8f10df1e34d40fe26be590ca1e25b1c33a0ff05451631",
+		},
+	}, *hashes)
+}
+
+func TestEnrichCDXHash_AppendsParsedIntegrity(t *testing.T) {
+	component := &cdx.Component{
+		Type:    cdx.ComponentTypeLibrary,
+		Name:    "fastapi",
+		Version: "0.115.0",
+	}
+	integrity := "sha256-17ea4276b66cf0ecf3a8f10df1e34d40fe26be590ca1e25b1c33a0ff05451631"
+	pkgVersionData := &packages.VersionWithDependencies{Integrity: &integrity}
+	logger := zerolog.Nop()
+
+	enrichCDXHash(component, pkgVersionData, &packages.Package{}, &logger)
+
+	require.NotNil(t, component.Hashes)
+	assert.Equal(t, []cdx.Hash{
+		{
+			Algorithm: cdx.HashAlgoSHA256,
+			Value:     "17ea4276b66cf0ecf3a8f10df1e34d40fe26be590ca1e25b1c33a0ff05451631",
+		},
+	}, *component.Hashes)
+}
+
+func TestEnrichCDXHash_AppendsToExistingHashes(t *testing.T) {
+	// syft already emits container-layer hashes; the enricher must preserve them.
+	existing := cdx.Hash{Algorithm: cdx.HashAlgoSHA256, Value: "0000000000000000000000000000000000000000000000000000000000000000"}
+	component := &cdx.Component{Hashes: &[]cdx.Hash{existing}}
+	integrity := "sha256-17ea4276b66cf0ecf3a8f10df1e34d40fe26be590ca1e25b1c33a0ff05451631"
+	logger := zerolog.Nop()
+
+	enrichCDXHash(component, &packages.VersionWithDependencies{Integrity: &integrity}, &packages.Package{}, &logger)
+
+	require.NotNil(t, component.Hashes)
+	assert.Len(t, *component.Hashes, 2)
+	assert.Equal(t, existing, (*component.Hashes)[0])
+}
+
+func TestEnrichCDXHash_NilIntegrityIsNoop(t *testing.T) {
+	// Go modules, Maven and other registries return null integrity — skip silently.
+	component := &cdx.Component{}
+	logger := zerolog.Nop()
+
+	enrichCDXHash(component, &packages.VersionWithDependencies{Integrity: nil}, &packages.Package{}, &logger)
+
+	assert.Nil(t, component.Hashes)
+}
+
+func TestEnrichCDXHash_UnparseableIsNoop(t *testing.T) {
+	component := &cdx.Component{}
+	bad := "sha999-not-actually-a-hash"
+	logger := zerolog.Nop()
+
+	enrichCDXHash(component, &packages.VersionWithDependencies{Integrity: &bad}, &packages.Package{}, &logger)
+
+	assert.Nil(t, component.Hashes)
 }
 
 func TestEnrichBlankSBOM(t *testing.T) {

--- a/lib/ecosystems/enrich_cyclonedx_test.go
+++ b/lib/ecosystems/enrich_cyclonedx_test.go
@@ -294,9 +294,8 @@ func TestEnrichCDXHash_AppendsParsedIntegrity(t *testing.T) {
 	}
 	integrity := "sha256-17ea4276b66cf0ecf3a8f10df1e34d40fe26be590ca1e25b1c33a0ff05451631"
 	pkgVersionData := &packages.VersionWithDependencies{Integrity: &integrity}
-	logger := zerolog.Nop()
 
-	enrichCDXHash(component, pkgVersionData, &packages.Package{}, &logger)
+	enrichCDXHash(component, pkgVersionData, &packages.Package{})
 
 	require.NotNil(t, component.Hashes)
 	assert.Equal(t, []cdx.Hash{
@@ -312,9 +311,8 @@ func TestEnrichCDXHash_AppendsToExistingHashes(t *testing.T) {
 	existing := cdx.Hash{Algorithm: cdx.HashAlgoSHA256, Value: "0000000000000000000000000000000000000000000000000000000000000000"}
 	component := &cdx.Component{Hashes: &[]cdx.Hash{existing}}
 	integrity := "sha256-17ea4276b66cf0ecf3a8f10df1e34d40fe26be590ca1e25b1c33a0ff05451631"
-	logger := zerolog.Nop()
 
-	enrichCDXHash(component, &packages.VersionWithDependencies{Integrity: &integrity}, &packages.Package{}, &logger)
+	enrichCDXHash(component, &packages.VersionWithDependencies{Integrity: &integrity}, &packages.Package{})
 
 	require.NotNil(t, component.Hashes)
 	assert.Len(t, *component.Hashes, 2)
@@ -324,9 +322,8 @@ func TestEnrichCDXHash_AppendsToExistingHashes(t *testing.T) {
 func TestEnrichCDXHash_NilIntegrityIsNoop(t *testing.T) {
 	// Go modules, Maven and other registries return null integrity — skip silently.
 	component := &cdx.Component{}
-	logger := zerolog.Nop()
 
-	enrichCDXHash(component, &packages.VersionWithDependencies{Integrity: nil}, &packages.Package{}, &logger)
+	enrichCDXHash(component, &packages.VersionWithDependencies{Integrity: nil}, &packages.Package{})
 
 	assert.Nil(t, component.Hashes)
 }
@@ -334,9 +331,8 @@ func TestEnrichCDXHash_NilIntegrityIsNoop(t *testing.T) {
 func TestEnrichCDXHash_UnparseableIsNoop(t *testing.T) {
 	component := &cdx.Component{}
 	bad := "sha999-not-actually-a-hash"
-	logger := zerolog.Nop()
 
-	enrichCDXHash(component, &packages.VersionWithDependencies{Integrity: &bad}, &packages.Package{}, &logger)
+	enrichCDXHash(component, &packages.VersionWithDependencies{Integrity: &bad}, &packages.Package{})
 
 	assert.Nil(t, component.Hashes)
 }

--- a/lib/ecosystems/enrich_cyclonedx_test.go
+++ b/lib/ecosystems/enrich_cyclonedx_test.go
@@ -286,6 +286,45 @@ func TestEnrichSBOM_CycloneDX_PopulatesHashFromIntegrity(t *testing.T) {
 	}, *hashes)
 }
 
+func TestEnrichSBOM_CycloneDX_MalformedIntegrityLeavesHashesUntouched(t *testing.T) {
+	// End-to-end guard: if ecosyste.ms ever serves an integrity value the
+	// parser can't decode, the pipeline must leave the component's Hashes
+	// alone rather than emitting a bogus entry.
+	ResetGlobalCache()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("GET", `=~^https://packages.ecosyste.ms/api/v1/registries/.*/packages/.*/versions`,
+		func(r *http.Request) (*http.Response, error) {
+			return httpmock.NewJsonResponse(200, map[string]any{
+				"integrity": "sha999-not-a-real-hash",
+			})
+		},
+	)
+	httpmock.RegisterResponder("GET", `=~^https://packages.ecosyste.ms/api/v1/registries`,
+		func(req *http.Request) (*http.Response, error) {
+			return httpmock.NewJsonResponse(200, map[string]any{})
+		})
+
+	bom := &cdx.BOM{
+		Components: &[]cdx.Component{
+			{
+				BOMRef:     "pkg:pypi/fastapi@0.115.0",
+				Type:       cdx.ComponentTypeLibrary,
+				Name:       "fastapi",
+				Version:    "0.115.0",
+				PackageURL: "pkg:pypi/fastapi@0.115.0",
+			},
+		},
+	}
+	doc := &sbom.SBOMDocument{BOM: bom}
+	logger := zerolog.Nop()
+
+	EnrichSBOM(doc, &logger)
+
+	assert.Nil(t, (*bom.Components)[0].Hashes)
+}
+
 func TestEnrichCDXHash_AppendsParsedIntegrity(t *testing.T) {
 	component := &cdx.Component{
 		Type:    cdx.ComponentTypeLibrary,

--- a/lib/ecosystems/enrich_spdx.go
+++ b/lib/ecosystems/enrich_spdx.go
@@ -68,7 +68,27 @@ func enrichSPDX(bom *spdx.Document, logger *zerolog.Logger) {
 		}
 
 		enrichSPDXLicense(pkg, pkgVersionData, pkgData)
+		enrichSPDXHash(pkg, pkgVersionData, logger)
 	}
+}
+
+// enrichSPDXHash appends a Checksum derived from ecosyste.ms' per-version
+// integrity field. Existing checksums are preserved.
+func enrichSPDXHash(pkg *v2_3.Package, pkgVersionData *packages.VersionWithDependencies, logger *zerolog.Logger) {
+	if pkgVersionData.Integrity == nil {
+		return
+	}
+	_, alg, value, ok := parseIntegrity(*pkgVersionData.Integrity)
+	if !ok {
+		logger.Debug().
+			Str("integrity", *pkgVersionData.Integrity).
+			Msg("Skipping checksum enrichment: unrecognised integrity format")
+		return
+	}
+	pkg.PackageChecksums = append(pkg.PackageChecksums, common.Checksum{
+		Algorithm: alg,
+		Value:     value,
+	})
 }
 
 func extractPurl(pkg *v2_3.Package) (*packageurl.PackageURL, error) {

--- a/lib/ecosystems/enrich_spdx.go
+++ b/lib/ecosystems/enrich_spdx.go
@@ -68,21 +68,18 @@ func enrichSPDX(bom *spdx.Document, logger *zerolog.Logger) {
 		}
 
 		enrichSPDXLicense(pkg, pkgVersionData, pkgData)
-		enrichSPDXHash(pkg, pkgVersionData, logger)
+		enrichSPDXHash(pkg, pkgVersionData)
 	}
 }
 
 // enrichSPDXHash appends a Checksum derived from ecosyste.ms' per-version
 // integrity field. Existing checksums are preserved.
-func enrichSPDXHash(pkg *v2_3.Package, pkgVersionData *packages.VersionWithDependencies, logger *zerolog.Logger) {
+func enrichSPDXHash(pkg *v2_3.Package, pkgVersionData *packages.VersionWithDependencies) {
 	if pkgVersionData.Integrity == nil {
 		return
 	}
 	_, alg, value, ok := parseIntegrity(*pkgVersionData.Integrity)
 	if !ok {
-		logger.Debug().
-			Str("integrity", *pkgVersionData.Integrity).
-			Msg("Skipping checksum enrichment: unrecognised integrity format")
 		return
 	}
 	pkg.PackageChecksums = append(pkg.PackageChecksums, common.Checksum{

--- a/lib/ecosystems/enrich_spdx_test.go
+++ b/lib/ecosystems/enrich_spdx_test.go
@@ -178,9 +178,8 @@ func TestEnrichSBOM_MissingVersionedLicense(t *testing.T) {
 func TestEnrichSPDXHash_AppendsParsedIntegrity(t *testing.T) {
 	pkg := &v2_3.Package{}
 	integrity := "sha256-17ea4276b66cf0ecf3a8f10df1e34d40fe26be590ca1e25b1c33a0ff05451631"
-	logger := zerolog.Nop()
 
-	enrichSPDXHash(pkg, &packages.VersionWithDependencies{Integrity: &integrity}, &logger)
+	enrichSPDXHash(pkg, &packages.VersionWithDependencies{Integrity: &integrity})
 
 	assert.Equal(t, []common.Checksum{
 		{
@@ -194,9 +193,8 @@ func TestEnrichSPDXHash_AppendsToExistingChecksums(t *testing.T) {
 	existing := common.Checksum{Algorithm: common.SHA1, Value: "0000000000000000000000000000000000000000"}
 	pkg := &v2_3.Package{PackageChecksums: []common.Checksum{existing}}
 	integrity := "sha256-17ea4276b66cf0ecf3a8f10df1e34d40fe26be590ca1e25b1c33a0ff05451631"
-	logger := zerolog.Nop()
 
-	enrichSPDXHash(pkg, &packages.VersionWithDependencies{Integrity: &integrity}, &logger)
+	enrichSPDXHash(pkg, &packages.VersionWithDependencies{Integrity: &integrity})
 
 	assert.Len(t, pkg.PackageChecksums, 2)
 	assert.Equal(t, existing, pkg.PackageChecksums[0])
@@ -204,9 +202,17 @@ func TestEnrichSPDXHash_AppendsToExistingChecksums(t *testing.T) {
 
 func TestEnrichSPDXHash_NilIntegrityIsNoop(t *testing.T) {
 	pkg := &v2_3.Package{}
-	logger := zerolog.Nop()
 
-	enrichSPDXHash(pkg, &packages.VersionWithDependencies{Integrity: nil}, &logger)
+	enrichSPDXHash(pkg, &packages.VersionWithDependencies{Integrity: nil})
+
+	assert.Nil(t, pkg.PackageChecksums)
+}
+
+func TestEnrichSPDXHash_UnparseableIsNoop(t *testing.T) {
+	pkg := &v2_3.Package{}
+	bad := "sha999-not-actually-a-hash"
+
+	enrichSPDXHash(pkg, &packages.VersionWithDependencies{Integrity: &bad})
 
 	assert.Nil(t, pkg.PackageChecksums)
 }

--- a/lib/ecosystems/enrich_spdx_test.go
+++ b/lib/ecosystems/enrich_spdx_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/snyk/parlay/ecosystems/packages"
 	"github.com/snyk/parlay/lib/sbom"
 )
 
@@ -172,6 +173,76 @@ func TestEnrichSBOM_MissingVersionedLicense(t *testing.T) {
 
 	buf := bytes.NewBuffer(nil)
 	require.NoError(t, doc.Encode(buf))
+}
+
+func TestEnrichSPDXHash_AppendsParsedIntegrity(t *testing.T) {
+	pkg := &v2_3.Package{}
+	integrity := "sha256-17ea4276b66cf0ecf3a8f10df1e34d40fe26be590ca1e25b1c33a0ff05451631"
+	logger := zerolog.Nop()
+
+	enrichSPDXHash(pkg, &packages.VersionWithDependencies{Integrity: &integrity}, &logger)
+
+	assert.Equal(t, []common.Checksum{
+		{
+			Algorithm: common.SHA256,
+			Value:     "17ea4276b66cf0ecf3a8f10df1e34d40fe26be590ca1e25b1c33a0ff05451631",
+		},
+	}, pkg.PackageChecksums)
+}
+
+func TestEnrichSPDXHash_AppendsToExistingChecksums(t *testing.T) {
+	existing := common.Checksum{Algorithm: common.SHA1, Value: "0000000000000000000000000000000000000000"}
+	pkg := &v2_3.Package{PackageChecksums: []common.Checksum{existing}}
+	integrity := "sha256-17ea4276b66cf0ecf3a8f10df1e34d40fe26be590ca1e25b1c33a0ff05451631"
+	logger := zerolog.Nop()
+
+	enrichSPDXHash(pkg, &packages.VersionWithDependencies{Integrity: &integrity}, &logger)
+
+	assert.Len(t, pkg.PackageChecksums, 2)
+	assert.Equal(t, existing, pkg.PackageChecksums[0])
+}
+
+func TestEnrichSPDXHash_NilIntegrityIsNoop(t *testing.T) {
+	pkg := &v2_3.Package{}
+	logger := zerolog.Nop()
+
+	enrichSPDXHash(pkg, &packages.VersionWithDependencies{Integrity: nil}, &logger)
+
+	assert.Nil(t, pkg.PackageChecksums)
+}
+
+func TestEnrichSBOM_SPDX_PopulatesChecksumFromIntegrity(t *testing.T) {
+	ResetGlobalCache()
+	packageVersionResponse := `{
+		"integrity": "sha256-17ea4276b66cf0ecf3a8f10df1e34d40fe26be590ca1e25b1c33a0ff05451631"
+	}`
+	packageResponse := `{}`
+	setupHttpmock(t, &packageVersionResponse, &packageResponse)
+	defer httpmock.DeactivateAndReset()
+
+	doc, err := sbom.DecodeSBOMDocument([]byte(`{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT"}`))
+	require.NoError(t, err)
+	bom := doc.BOM.(*v2_3.Document)
+	bom.Packages = []*v2_3.Package{
+		{
+			PackageSPDXIdentifier: "pkg:pypi/fastapi@0.115.0",
+			PackageName:           "fastapi",
+			PackageVersion:        "0.115.0",
+			PackageExternalReferences: []*v2_3.PackageExternalReference{
+				{Category: common.CategoryPackageManager, RefType: "purl", Locator: "pkg:pypi/fastapi@0.115.0"},
+			},
+		},
+	}
+	logger := zerolog.Nop()
+
+	EnrichSBOM(doc, &logger)
+
+	assert.Equal(t, []common.Checksum{
+		{
+			Algorithm: common.SHA256,
+			Value:     "17ea4276b66cf0ecf3a8f10df1e34d40fe26be590ca1e25b1c33a0ff05451631",
+		},
+	}, bom.Packages[0].PackageChecksums)
 }
 
 func TestEnrichSBOM_SPDX_NoSupplierName(t *testing.T) {

--- a/lib/ecosystems/integrity.go
+++ b/lib/ecosystems/integrity.go
@@ -1,0 +1,67 @@
+/*
+ * © 2026 Snyk Limited All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ecosystems
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"strings"
+
+	cdx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/spdx/tools-golang/spdx/v2/common"
+)
+
+type integrityAlg struct {
+	cdxAlg    cdx.HashAlgorithm
+	spdxAlg   common.ChecksumAlgorithm
+	byteCount int
+}
+
+var integrityAlgs = map[string]integrityAlg{
+	"sha256": {cdx.HashAlgoSHA256, common.SHA256, 32},
+	"sha512": {cdx.HashAlgoSHA512, common.SHA512, 64},
+}
+
+// parseIntegrity parses the "<alg>-<encoded>" integrity string served by
+// ecosyste.ms and returns the matching CycloneDX and SPDX algorithm
+// identifiers plus a lowercase hex-encoded digest value. The encoded
+// portion may be raw hex (PyPI, RubyGems) or base64 (npm Subresource
+// Integrity); both are normalised to hex on output.
+func parseIntegrity(s string) (cdx.HashAlgorithm, common.ChecksumAlgorithm, string, bool) {
+	algStr, value, found := strings.Cut(s, "-")
+	if !found {
+		return "", "", "", false
+	}
+	alg, known := integrityAlgs[strings.ToLower(algStr)]
+	if !known {
+		return "", "", "", false
+	}
+
+	// Hex: length is exactly 2× the digest size and decodes cleanly.
+	if len(value) == alg.byteCount*2 {
+		if _, err := hex.DecodeString(value); err == nil {
+			return alg.cdxAlg, alg.spdxAlg, strings.ToLower(value), true
+		}
+	}
+	// Base64 (standard or URL-safe), as used by npm SRI.
+	for _, enc := range []*base64.Encoding{base64.StdEncoding, base64.URLEncoding} {
+		if b, err := enc.DecodeString(value); err == nil && len(b) == alg.byteCount {
+			return alg.cdxAlg, alg.spdxAlg, hex.EncodeToString(b), true
+		}
+	}
+	return "", "", "", false
+}

--- a/lib/ecosystems/integrity.go
+++ b/lib/ecosystems/integrity.go
@@ -57,8 +57,11 @@ func parseIntegrity(s string) (cdx.HashAlgorithm, common.ChecksumAlgorithm, stri
 			return alg.cdxAlg, alg.spdxAlg, strings.ToLower(value), true
 		}
 	}
-	// Base64 (standard or URL-safe), as used by npm SRI.
-	for _, enc := range []*base64.Encoding{base64.StdEncoding, base64.URLEncoding} {
+	// Base64 (standard or URL-safe, padded or raw), as used by npm SRI.
+	for _, enc := range []*base64.Encoding{
+		base64.StdEncoding, base64.URLEncoding,
+		base64.RawStdEncoding, base64.RawURLEncoding,
+	} {
 		if b, err := enc.DecodeString(value); err == nil && len(b) == alg.byteCount {
 			return alg.cdxAlg, alg.spdxAlg, hex.EncodeToString(b), true
 		}

--- a/lib/ecosystems/integrity_test.go
+++ b/lib/ecosystems/integrity_test.go
@@ -1,0 +1,74 @@
+/*
+ * © 2026 Snyk Limited All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ecosystems
+
+import (
+	"testing"
+
+	cdx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/spdx/tools-golang/spdx/v2/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseIntegrity_PyPIHex(t *testing.T) {
+	// PyPI/RubyGems serve "<alg>-<hex>" — fastapi 0.115.0 from the issue probe.
+	cdxAlg, spdxAlg, value, ok := parseIntegrity(
+		"sha256-17ea4276b66cf0ecf3a8f10df1e34d40fe26be590ca1e25b1c33a0ff05451631",
+	)
+
+	assert.True(t, ok)
+	assert.Equal(t, cdx.HashAlgoSHA256, cdxAlg)
+	assert.Equal(t, common.SHA256, spdxAlg)
+	assert.Equal(t,
+		"17ea4276b66cf0ecf3a8f10df1e34d40fe26be590ca1e25b1c33a0ff05451631",
+		value,
+	)
+}
+
+func TestParseIntegrity_RejectsBadInput(t *testing.T) {
+	// Each case is a string the parser must report as unparseable so the
+	// outer loop can debug-log and skip rather than emit a bogus hash.
+	cases := map[string]string{
+		"empty":            "",
+		"no separator":     "sha256abcd",
+		"unknown alg":      "sha999-deadbeef",
+		"truncated hex":    "sha256-deadbeef",
+		"hex wrong chars":  "sha256-zzzz4276b66cf0ecf3a8f10df1e34d40fe26be590ca1e25b1c33a0ff05451631",
+		"base64 wrong len": "sha512-AAAA",
+	}
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, _, _, ok := parseIntegrity(input)
+			assert.False(t, ok)
+		})
+	}
+}
+
+func TestParseIntegrity_NPMSubresourceIntegrity(t *testing.T) {
+	// npm serves SRI "<alg>-<base64>". Parser must decode to hex.
+	cdxAlg, spdxAlg, value, ok := parseIntegrity(
+		"sha512-m3HSJL1i83hdltRq0+o9czGb+8KJDKra4t/3JRlnPKcjI8PZm6XBHXx6zG4UuMXaDEZjR1wuXDre9G9zvN7AQw==",
+	)
+
+	assert.True(t, ok)
+	assert.Equal(t, cdx.HashAlgoSHA512, cdxAlg)
+	assert.Equal(t, common.SHA512, spdxAlg)
+	assert.Equal(t,
+		"9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec043",
+		value,
+	)
+}


### PR DESCRIPTION
Closes #144

## Summary

- Adds `parseIntegrity` to normalise the `"<alg>-<encoded>"` strings ecosyste.ms serves on per-version package responses (hex for PyPI/RubyGems, base64 SRI for npm).
- Adds `enrichCDXHash` (CycloneDX `component.hashes[]`) and `enrichSPDXHash` (SPDX `package.checksums[]`) wired into the existing enrichment loops. No new HTTP calls — the version response is already fetched via the shared cache.
- Append, never overwrite: existing hashes (e.g. syft's container-layer digests) are preserved.
- Algorithms covered today: `sha256` and `sha512`. ecosyste.ms returns `null` integrity for Cargo, Packagist, Go modules, and Maven; those packages are left untouched.

## Test plan

- [x] `go test ./lib/ecosystems/...` — unit + integration tests pass.
- [x] Parser tests for PyPI hex, npm SRI base64, and rejection cases (unknown alg, truncated hex, wrong base64 length, etc.).
- [x] CDX/SPDX enricher tests: parsed-integrity, append-to-existing, nil-is-noop, unparseable-is-noop.
- [x] End-to-end `EnrichSBOM` tests for both CDX and SPDX with mocked ecosyste.ms responses.
- [ ] Manual smoke against a real SBOM (e.g. `uv export --format cyclonedx` for a PyPI project) before marking ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)