### PR TITLE
Use sizedwaitgroup to enrich SPDX

### DIFF
--- a/lib/ecosystems/enrich_spdx.go
+++ b/lib/ecosystems/enrich_spdx.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/package-url/packageurl-go"
+	"github.com/remeh/sizedwaitgroup"
 	"github.com/rs/zerolog"
 	"github.com/spdx/tools-golang/spdx"
 	"github.com/spdx/tools-golang/spdx/v2/common"
@@ -36,39 +37,46 @@ func enrichSPDX(bom *spdx.Document, logger *zerolog.Logger) {
 	logger.Debug().Msgf("Detected %d packages", len(packages))
 
 	cache := GetGlobalCache()
+	wg := sizedwaitgroup.New(20)
+	for i := range packages {
+		wg.Add()
+		go func(pkg *v2_3.Package) {
+			defer wg.Done()
 
-	for _, pkg := range packages {
-		purl, err := extractPurl(pkg)
-		if err != nil {
-			continue
-		}
+			purl, err := extractPurl(pkg)
+			if err != nil {
+				return
+			}
 
-		packageResp, err := cache.GetPackageData(*purl)
-		if err != nil {
-			continue
-		}
+			packageResp, err := cache.GetPackageData(*purl)
+			if err != nil {
+				return
+			}
 
-		pkgData := packageResp.JSON200
-		if pkgData == nil {
-			continue
-		}
+			pkgData := packageResp.JSON200
+			if pkgData == nil {
+				return
+			}
 
-		enrichSPDXDescription(pkg, pkgData)
-		enrichSPDXHomepage(pkg, pkgData)
-		enrichSPDXSupplier(pkg, pkgData)
+			enrichSPDXDescription(pkg, pkgData)
+			enrichSPDXHomepage(pkg, pkgData)
+			enrichSPDXSupplier(pkg, pkgData)
 
-		packageVersionResp, err := cache.GetPackageVersionData(*purl)
-		if err != nil {
-			continue
-		}
+			packageVersionResp, err := cache.GetPackageVersionData(*purl)
+			if err != nil {
+				return
+			}
 
-		pkgVersionData := packageVersionResp.JSON200
-		if pkgVersionData == nil {
-			continue
-		}
+			pkgVersionData := packageVersionResp.JSON200
+			if pkgVersionData == nil {
+				return
+			}
 
-		enrichSPDXLicense(pkg, pkgVersionData, pkgData)
+			enrichSPDXLicense(pkg, pkgVersionData, pkgData)
+		}(packages[i])
 	}
+
+	wg.Wait()
 }
 
 func extractPurl(pkg *v2_3.Package) (*packageurl.PackageURL, error) {

--- a/lib/ecosystems/enrich_spdx_test.go
+++ b/lib/ecosystems/enrich_spdx_test.go
@@ -19,6 +19,7 @@ package ecosystems
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -211,6 +212,137 @@ func TestEnrichSBOM_SPDX_NoSupplierName(t *testing.T) {
 	logger := zerolog.Nop()
 
 	EnrichSBOM(doc, &logger)
+
+	buf := bytes.NewBuffer(nil)
+	require.NoError(t, doc.Encode(buf))
+}
+
+func TestEnrichSBOM_SPDX_MultiplePackages(t *testing.T) {
+	ResetGlobalCache()
+	packageVersionResponse := `{
+		"licenses": "MIT"
+	}`
+	packageResponse := `{
+		"description": "a package",
+		"normalized_licenses": ["MIT"],
+		"homepage": "https://github.com/example/pkg",
+		"repo_metadata": {
+			"owner_record": {
+				"name": "Example Org"
+			}
+		}
+	}`
+	setupHttpmock(t, &packageVersionResponse, &packageResponse)
+	defer httpmock.DeactivateAndReset()
+
+	doc, err := sbom.DecodeSBOMDocument([]byte(`{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT"}`))
+	require.NoError(t, err)
+
+	bom, ok := doc.BOM.(*v2_3.Document)
+	require.True(t, ok)
+
+	// Create 50 packages to exercise concurrent processing
+	bom.Packages = make([]*v2_3.Package, 50)
+	for i := range bom.Packages {
+		bom.Packages[i] = &v2_3.Package{
+			PackageSPDXIdentifier: common.ElementID(fmt.Sprintf("SPDXRef-pkg%d", i)),
+			PackageName:           fmt.Sprintf("github.com/example/pkg%d", i),
+			PackageVersion:        "v1.0.0",
+			PackageExternalReferences: []*v2_3.PackageExternalReference{
+				{
+					Category: common.CategoryPackageManager,
+					RefType:  "purl",
+					Locator:  fmt.Sprintf("pkg:golang/github.com/example/pkg%d@v1.0.0", i),
+				},
+			},
+		}
+	}
+	logger := zerolog.Nop()
+
+	EnrichSBOM(doc, &logger)
+
+	// Verify all packages were enriched
+	for i, pkg := range bom.Packages {
+		assert.Equal(t, "a package", pkg.PackageDescription, "package %d description", i)
+		assert.Equal(t, "https://github.com/example/pkg", pkg.PackageHomePage, "package %d homepage", i)
+		assert.Equal(t, "MIT", pkg.PackageLicenseConcluded, "package %d license", i)
+		assert.Equal(t, "Organization", pkg.PackageSupplier.SupplierType, "package %d supplier type", i)
+		assert.Equal(t, "Example Org", pkg.PackageSupplier.Supplier, "package %d supplier", i)
+	}
+
+	buf := bytes.NewBuffer(nil)
+	require.NoError(t, doc.Encode(buf))
+}
+
+func TestEnrichSBOM_SPDX_PackagesWithoutPurl(t *testing.T) {
+	ResetGlobalCache()
+	packageVersionResponse := `{
+		"licenses": "Apache-2.0"
+	}`
+	packageResponse := `{
+		"description": "enriched",
+		"homepage": "https://github.com/example/valid",
+		"repo_metadata": {}
+	}`
+	setupHttpmock(t, &packageVersionResponse, &packageResponse)
+	defer httpmock.DeactivateAndReset()
+
+	doc, err := sbom.DecodeSBOMDocument([]byte(`{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT"}`))
+	require.NoError(t, err)
+
+	bom, ok := doc.BOM.(*v2_3.Document)
+	require.True(t, ok)
+
+	bom.Packages = []*v2_3.Package{
+		{
+			PackageSPDXIdentifier: "SPDXRef-valid",
+			PackageName:           "github.com/example/valid",
+			PackageVersion:        "v1.0.0",
+			PackageExternalReferences: []*v2_3.PackageExternalReference{
+				{
+					Category: common.CategoryPackageManager,
+					RefType:  "purl",
+					Locator:  "pkg:golang/github.com/example/valid@v1.0.0",
+				},
+			},
+		},
+		{
+			// Package without any external references (no purl)
+			PackageSPDXIdentifier: "SPDXRef-nopurl",
+			PackageName:           "internal-package",
+			PackageVersion:        "0.0.1",
+		},
+		{
+			PackageSPDXIdentifier: "SPDXRef-valid2",
+			PackageName:           "github.com/example/valid2",
+			PackageVersion:        "v2.0.0",
+			PackageExternalReferences: []*v2_3.PackageExternalReference{
+				{
+					Category: common.CategoryPackageManager,
+					RefType:  "purl",
+					Locator:  "pkg:golang/github.com/example/valid2@v2.0.0",
+				},
+			},
+		},
+	}
+	logger := zerolog.Nop()
+
+	EnrichSBOM(doc, &logger)
+
+	// Valid packages should be enriched
+	assert.Equal(t, "enriched", bom.Packages[0].PackageDescription)
+	assert.Equal(t, "https://github.com/example/valid", bom.Packages[0].PackageHomePage)
+	assert.Equal(t, "Apache-2.0", bom.Packages[0].PackageLicenseConcluded)
+
+	// Package without purl should be untouched
+	assert.Equal(t, "", bom.Packages[1].PackageDescription)
+	assert.Equal(t, "", bom.Packages[1].PackageHomePage)
+	assert.Equal(t, "", bom.Packages[1].PackageLicenseConcluded)
+
+	// Second valid package should also be enriched
+	assert.Equal(t, "enriched", bom.Packages[2].PackageDescription)
+	assert.Equal(t, "https://github.com/example/valid", bom.Packages[2].PackageHomePage)
+	assert.Equal(t, "Apache-2.0", bom.Packages[2].PackageLicenseConcluded)
 
 	buf := bytes.NewBuffer(nil)
 	require.NoError(t, doc.Encode(buf))


### PR DESCRIPTION
I regularly enrich SPDX SBOMs with 300+ and 600+ packages.  That typically takes more than 10 minutes.  Replicating the batching that was implemented for CycloneDX gets that down to around 45 seconds.