### PR TITLE
feat: add support for CycloneDX 1.7

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -10,6 +10,11 @@
   [ "$status" -eq 0 ]
 }
 
+@test "Not fail when testing a CycloneDX 1.7 SBOM" {
+  run ./parlay ecosystems enrich testing/sbom.cyclonedx-1.7.json
+  [ "$status" -eq 0 ]
+}
+
 @test "Not fail when testing an SBOM on stdin" {
   run bash -c "cat testing/sbom.cyclonedx.json | ./parlay ecosystems enrich -"
   [ "$status" -eq 0 ]

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/snyk/parlay
 go 1.26.3
 
 require (
-	github.com/CycloneDX/cyclonedx-go v0.9.2
+	github.com/CycloneDX/cyclonedx-go v0.11.0
 	github.com/deepmap/oapi-codegen v1.12.4
 	github.com/edoardottt/depsdev v0.0.3
 	github.com/google/uuid v1.5.0
@@ -16,7 +16,7 @@ require (
 	github.com/spdx/tools-golang v0.5.4-0.20240304222056-8baafa1a79c4
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.15.0
-	github.com/stretchr/testify v1.10.0
+	github.com/stretchr/testify v1.11.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3f
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/CycloneDX/cyclonedx-go v0.9.2 h1:688QHn2X/5nRezKe2ueIVCt+NRqf7fl3AVQk+vaFcIo=
-github.com/CycloneDX/cyclonedx-go v0.9.2/go.mod h1:vcK6pKgO1WanCdd61qx4bFnSsDJQ6SbM2ZuMIgq86Jg=
+github.com/CycloneDX/cyclonedx-go v0.11.0 h1:GokP8FiRC+foiuwWhSSLpSD5H4hSWtGnR3wo7apkBFI=
+github.com/CycloneDX/cyclonedx-go v0.11.0/go.mod h1:vUvbCXQsEm48OI6oOlanxstwNByXjCZ2wuleUlwGEO8=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/anchore/go-struct-converter v0.0.0-20221118182256-c68fdcfa2092 h1:aM1rlcoLz8y5B2r4tTLMiVTrMtpfY0O8EScKJxaSaEc=
 github.com/anchore/go-struct-converter v0.0.0-20221118182256-c68fdcfa2092/go.mod h1:rYqSE9HbjzpHTI74vwPvae4ZVYZd1lue2ta6xHPdblA=
@@ -232,8 +232,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8=
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/terminalstatic/go-xsd-validate v0.1.6 h1:TenYeQ3eY631qNi1/cTmLH/s2slHPRKTTHT+XSHkepo=

--- a/lib/sbom/decode_test.go
+++ b/lib/sbom/decode_test.go
@@ -17,6 +17,7 @@
 package sbom
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/CycloneDX/cyclonedx-go"
@@ -29,6 +30,8 @@ import (
 var (
 	fixedCycloneDX1_4JSON = []byte(`{"bomFormat":"CycloneDX","specVersion":"1.4","version":1}`)
 	fixedCycloneDX1_4XML  = []byte(`<bom xmlns="http://cyclonedx.org/schema/bom/1.4" version="1"></bom>`)
+	fixedCycloneDX1_7JSON = []byte(`{"bomFormat":"CycloneDX","specVersion":"1.7","version":1,"citations":[{"note":"source"}]}`)
+	fixedCycloneDX1_7XML  = []byte(`<bom xmlns="http://cyclonedx.org/schema/bom/1.7" version="1"><citations><citation><note>source</note></citation></citations></bom>`)
 	fixedSPDX2_3JSON      = []byte(`{"SPDXID":"SPDXRef-DOCUMENT","spdxVersion":"SPDX-2.3"}`)
 	fixedSPDX2_2JSON      = []byte(`{"SPDXID":"SPDXRef-DOCUMENT","spdxVersion":"SPDX-2.2"}`)
 )
@@ -55,6 +58,42 @@ func TestDecodeSBOMDocument_CycloneDX1_4XML(t *testing.T) {
 	assert.Equal(t, SBOMFormatCycloneDX1_4XML, doc.Format)
 	assert.NotNil(t, doc.Encode)
 	assert.Equal(t, cyclonedx.SpecVersion1_4, bom.SpecVersion)
+}
+
+func TestDecodeSBOMDocument_CycloneDX1_7JSON(t *testing.T) {
+	doc, err := DecodeSBOMDocument(fixedCycloneDX1_7JSON)
+	require.NoError(t, err)
+
+	bom, ok := doc.BOM.(*cyclonedx.BOM)
+	require.True(t, ok)
+
+	assert.Equal(t, cyclonedx.SpecVersion1_7, bom.SpecVersion)
+	require.NotNil(t, bom.Citations)
+	require.Len(t, *bom.Citations, 1)
+	assert.Equal(t, "source", (*bom.Citations)[0].Note)
+
+	var output bytes.Buffer
+	require.NoError(t, doc.Encode(&output))
+	assert.Contains(t, output.String(), `"specVersion":"1.7"`)
+	assert.Contains(t, output.String(), `"citations":[{"note":"source"}]`)
+}
+
+func TestDecodeSBOMDocument_CycloneDX1_7XML(t *testing.T) {
+	doc, err := DecodeSBOMDocument(fixedCycloneDX1_7XML)
+	require.NoError(t, err)
+
+	bom, ok := doc.BOM.(*cyclonedx.BOM)
+	require.True(t, ok)
+
+	assert.Equal(t, cyclonedx.SpecVersion1_7, bom.SpecVersion)
+	require.NotNil(t, bom.Citations)
+	require.Len(t, *bom.Citations, 1)
+	assert.Equal(t, "source", (*bom.Citations)[0].Note)
+
+	var output bytes.Buffer
+	require.NoError(t, doc.Encode(&output))
+	assert.Contains(t, output.String(), `xmlns="http://cyclonedx.org/schema/bom/1.7"`)
+	assert.Contains(t, output.String(), `<citations><citation><note>source</note></citation></citations>`)
 }
 
 func TestDecodeSBOMDocument_SPDX2_3JSON(t *testing.T) {

--- a/testing/sbom.cyclonedx-1.7.json
+++ b/testing/sbom.cyclonedx-1.7.json
@@ -1,0 +1,10 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.7",
+  "version": 1,
+  "citations": [
+    {
+      "note": "source"
+    }
+  ]
+}


### PR DESCRIPTION
Upgrades `cyclonedx-go` to v0.11.0 so Parlay can decode and encode CycloneDX 1.7 JSON and XML documents.

Adds round-trip coverage for 1.7-only citations and an acceptance fixture.

Closes #136.