### PR TITLE
fix(circleci): use open_source-managed context for security-scans

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,5 +34,5 @@ workflows:
       - security-scans:
           name: Security Scans
           context:
-            - analysis_unify
+            - open_source-managed
             - prodsec-orb-runtime


### PR DESCRIPTION
## Summary
- The `security-scans` job (wrapping `prodsec/security_scans`) in `.circleci/config.yml` was using the `analysis_unify` CircleCI context.
- Standardizing on `open_source-managed`, the context used by the large majority of `snyk/engines_sca-scanners`-owned repos for this job.

## Context
Identified as part of an audit of `prodsec/security_scans`, `prodsec/container_scan`, and `publish/publish` CircleCI contexts across all sca-scanners repos.

## Test plan
- [ ] Confirm the `security-scans` job runs successfully on this branch/PR with the new context
- [ ] Confirm `SNYK_TOKEN` and other required env vars are present in `open_source-managed`